### PR TITLE
PR #163: Update type annotations for RepeatedMetaType and MetaItem in rde2types

### DIFF
--- a/src/rdetoolkit/models/rde2types.py
+++ b/src/rdetoolkit/models/rde2types.py
@@ -17,8 +17,8 @@ PathTuple = tuple[Path, ...]
 InputFilesGroup = tuple[ZipFilesPathList, ExcelInvoicePathList, OtherFilesPathList]
 RawFiles = Sequence[PathTuple]
 MetaType = dict[str, Union[str, int, float, list, bool]]
-RepeatedMetaType = dict[str, list[Union[str, int, float]]]
-MetaItem = dict[str, Union[str, int, float, bool]]
+RepeatedMetaType = dict[str, list[Union[str, int, float, list, bool]]]
+MetaItem = dict[str, Union[str, int, float, list, bool]]
 RdeFsPath = Union[str, Path]
 
 

--- a/src/rdetoolkit/models/rde2types.pyi
+++ b/src/rdetoolkit/models/rde2types.pyi
@@ -12,8 +12,8 @@ PathTuple = tuple[Path, ...]
 InputFilesGroup = tuple[ZipFilesPathList, ExcelInvoicePathList, OtherFilesPathList]
 RawFiles = Sequence[PathTuple]
 MetaType = dict[str, str | int | float | list | bool]
-RepeatedMetaType = dict[str, list[str | int | float]]
-MetaItem = dict[str, str | int | float | bool]
+RepeatedMetaType = dict[str, list[str | int | float | list | bool]]
+MetaItem = dict[str, str | int | float | list | bool | bool]
 RdeFsPath = str | Path
 
 @dataclass


### PR DESCRIPTION
## Summary

This PR updates type annotations in `rde2types.py` and `rde2types.pyi` to improve the type definitions for `RepeatedMetaType` and `MetaItem`.

## Changes Made

### Modified Files
- `src/rdetoolkit/models/rde2types.py`
- `src/rdetoolkit/models/rde2types.pyi`

### Type Definition Updates

#### RepeatedMetaType
**Before:**
```python
RepeatedMetaType = dict[str, list[Union[str, int, float]]]
```

**After:**
```python
RepeatedMetaType = dict[str, list[Union[str, int, float, list, bool]]]
```

#### MetaItem
**Before:**
```python
MetaItem = dict[str, Union[str, int, float, bool]]
```

**After:**
```python
MetaItem = dict[str, Union[str, int, float, list, bool]]
```

## Rationale

- Enhanced `RepeatedMetaType` to support `list` and `bool` types in addition to existing types, enabling more complex data structures
- Added `list` type support to `MetaItem` to handle array data
- Maintains backward compatibility while expanding support for diverse data types

## Related issue

- **Related Issue**:  #163