### PR TITLE
PR #144: Fix empty sheet generation for Excel invoice templates

### DIFF
--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -438,13 +438,13 @@ class ExcelInvoiceTemplateGenerator:
                 name = key_name.replace(f"{attr_config.prefix}.", "")
                 base_df[key_name] = [None, attr_config.prefix, name, ja_name]
 
-        df_registerd_general = pd.DataFrame(
-            registerd_general_terms,
-            columns=["term_id", "key_name"] if not registerd_general_terms else None,
+        df_registered_general = pd.DataFrame(
+            registered_general_terms,
+            columns=["term_id", "key_name"] if not registered_general_terms else None,
         )
-        df_registerd_specific = pd.DataFrame(
-            registerd_specific_terms,
-            columns=["sample_class_id", "term_id", "key_name"] if not registerd_specific_terms else None,
+        df_registered_specific = pd.DataFrame(
+            registered_specific_terms,
+            columns=["sample_class_id", "term_id", "key_name"] if not registered_specific_terms else None,
         )
 
         return base_df, df_registerd_general, df_registerd_specific

--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -401,6 +401,10 @@ class ExcelInvoiceTemplateGenerator:
         for attr_config in attribute_configs:
             attrs = attr_config.attributes
             if not attrs or not attrs.items.root:
+                if isinstance(attr_config, GeneralAttributeConfig):
+                    registerd_general_terms = []
+                elif isinstance(attr_config, SpecificAttributeConfig):
+                    registerd_specific_terms = []
                 continue
 
             for prop in attrs.items.root:
@@ -434,8 +438,14 @@ class ExcelInvoiceTemplateGenerator:
                 name = key_name.replace(f"{attr_config.prefix}.", "")
                 base_df[key_name] = [None, attr_config.prefix, name, ja_name]
 
-        df_registerd_general = pd.DataFrame(registerd_general_terms)
-        df_registerd_specific = pd.DataFrame(registerd_specific_terms)
+        df_registerd_general = pd.DataFrame(
+            registerd_general_terms,
+            columns=["term_id", "key_name"] if not registerd_general_terms else None,
+        )
+        df_registerd_specific = pd.DataFrame(
+            registerd_specific_terms,
+            columns=["sample_class_id", "term_id", "key_name"] if not registerd_specific_terms else None,
+        )
 
         return base_df, df_registerd_general, df_registerd_specific
 

--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -396,15 +396,15 @@ class ExcelInvoiceTemplateGenerator:
                 requires_class_id=True,
             ),
         ]
-        registerd_general_terms = []
-        registerd_specific_terms = []
+        registered_general_terms = []
+        registered_specific_terms = []
         for attr_config in attribute_configs:
             attrs = attr_config.attributes
             if not attrs or not attrs.items.root:
                 if isinstance(attr_config, GeneralAttributeConfig):
-                    registerd_general_terms = []
+                    registered_general_terms = []
                 elif isinstance(attr_config, SpecificAttributeConfig):
-                    registerd_specific_terms = []
+                    registered_specific_terms = []
                 continue
 
             for prop in attrs.items.root:
@@ -418,7 +418,7 @@ class ExcelInvoiceTemplateGenerator:
                     if isinstance(attr_config, SpecificAttributeConfig):
                         emsg = f"Could not find a result corresponding to term_id {term_id} and class_id {class_id}."
                         term = attr_config.registry.by_term_and_class_id(term_id, class_id)[0]
-                        registerd_specific_terms.append({
+                        registered_specific_terms.append({
                             "sample_class_id": class_id,
                             "term_id": term_id,
                             "key_name": term["key_name"],
@@ -426,7 +426,7 @@ class ExcelInvoiceTemplateGenerator:
                     else:
                         emsg = f"Could not find a result corresponding to term_id {term_id}."
                         term = attr_config.registry.by_term_id(term_id)[0]
-                        registerd_general_terms.append({
+                        registered_general_terms.append({
                             "term_id": term_id,
                             "key_name": term["key_name"],
                         })
@@ -447,7 +447,7 @@ class ExcelInvoiceTemplateGenerator:
             columns=["sample_class_id", "term_id", "key_name"] if not registered_specific_terms else None,
         )
 
-        return base_df, df_registerd_general, df_registerd_specific
+        return base_df, df_registered_general, df_registered_specific
 
     def save(self, dataframes: dict[str, pd.DataFrame], save_path: str) -> None:
         """Save the given DataFrame to an Excel file with specific formatting.

--- a/tests/fixtures/invoice.py
+++ b/tests/fixtures/invoice.py
@@ -402,3 +402,89 @@ def ivnoice_json_magic_filename_variable() -> Generator[str, None, None]:
     # teardown
     if os.path.exists("data"):
         shutil.rmtree("data")
+
+
+@pytest.fixture
+def empty_attributes_schema(tmp_path):
+    """スキーマファイル（generalAttributes、specificAttributesが空）を作成."""
+    schema_content = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "test_empty_attributes",
+        "type": "object",
+        "required": ["custom", "sample"],
+        "properties": {
+            "custom": {
+                "type": "object",
+                "label": {"ja": "固有情報", "en": "Custom Information"},
+                "required": [],
+                "properties": {
+                    "test_field": {
+                        "label": {"ja": "テストフィールド", "en": "Test Field"},
+                        "type": "string"
+                    }
+                }
+            },
+            "sample": {
+                "type": "object",
+                "label": {"ja": "試料情報", "en": "Sample Information"},
+                "properties": {}
+            }
+        }
+    }
+    schema_file = tmp_path / "empty_attributes.schema.json"
+    with open(schema_file, "w", encoding="utf-8") as f:
+        json.dump(schema_content, f, ensure_ascii=False, indent=2)
+
+    return schema_file
+
+
+@pytest.fixture
+def empty_general_attributes_schema(tmp_path):
+    """スキーマファイル（generalAttributesのみ空）を作成."""
+    schema_content = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "test_empty_general_attributes",
+        "type": "object",
+        "required": [
+            "custom",
+            "sample"
+        ],
+        "properties": {
+            "custom": {
+                "type": "object",
+                "label": {"ja": "固有情報", "en": "Custom Information"},
+                "required": [],
+                "properties": {
+                    "test_field": {
+                        "label": {"ja": "テストフィールド", "en": "Test Field"},
+                        "type": "string"
+                    }
+                }
+            },
+            "sample": {
+                "type": "object",
+                "label": {"ja": "試料情報", "en": "Sample Information"},
+                "properties": {
+                    "specificAttributes": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "object",
+                                "required": ["classId", "termId"],
+                                "properties": {
+                                    "classId": {"const": "01cb3c01-37a4-5a43-d8ca-f523ca99a75b"},
+                                    "termId": {"const": "3250c45d-0ed6-1438-43b5-eb679918604a"}
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    schema_file = tmp_path / "empty_general_attributes.schema.json"
+    with open(schema_file, "w", encoding="utf-8") as f:
+        json.dump(schema_content, f, ensure_ascii=False, indent=2)
+
+    return schema_file


### PR DESCRIPTION

## Summary

Fixed an issue where empty sheets were generated when `generalAttributes` or `specificAttributes` are not defined in invoice.schema.json during Excel invoice template generation. This change ensures that when attributes are undefined, sheets with header rows only are generated.

## Background

When creating Excel invoices via CLI, depending on the contents of invoice.schema.json, generalTerm and specificTerm sheets could become completely empty. This causes errors in structured processing and reduces the practical usability of the templates.

## Changes

### Issues Fixed

- Empty generalTerm sheets generated when `generalAttributes` is undefined or empty
- Empty specificTerm sheets generated when `specificAttributes` is undefined or empty

### New Behavior

- When attributes are undefined, generate sheets with header rows only
- **generalTerm sheet**: `term_id` | `key_name`
- **specificTerm sheet**: `sample_class_id` | `term_id` | `key_name`

## Technical Implementation Details

### Modified Files

#### 1. `src/rdetoolkit/invoicefile.py`
- Modified `ExcelInvoiceTemplateGenerator._add_sample_field()` method
- Added header-only DataFrame creation when empty attributes are detected

```python
# Summary of modifications
if not attrs or not attrs.items.root:
    if isinstance(attr_config, GeneralAttributeConfig):
        registerd_general_terms = []  # Empty data
    elif isinstance(attr_config, SpecificAttributeConfig):
        registerd_specific_terms = []  # Empty data
    continue

# Proper column specification during DataFrame creation
df_registerd_general = pd.DataFrame(
    registerd_general_terms,
    columns=["term_id", "key_name"] if not registerd_general_terms else None,
)
```

### Key Design Decisions

1. **Header-only generation**: Provide clear header structure only, not full item enumeration
2. **Preserve existing functionality**: No changes to behavior when attributes are defined
3. **Simple implementation**: No additional CSV file reading or method additions required

## Tests

### Added Test Cases

#### 1. Basic Functionality Tests
- `test_empty_attributes_generates_header_only_sheets()`: Verify header-only generation for empty attributes
- `test_excel_header_structure_with_empty_attributes()`: Validate Excel file header structure

#### 2. Partial Empty Attributes Test
- `test_mixed_empty_and_defined_attributes()`: Verify behavior when only some attributes are defined

#### 3. Backward Compatibility Test
- `test_backward_compatibility_with_defined_attributes()`: Confirm no impact on existing functionality

#### 4. Integration Test
- `test_cli_integration_header_only()`: Verify CLI command operation

### Test Fixtures
- `empty_attributes_schema`: Schema file without attributes
- `empty_general_attributes_schema`: Schema file with empty generalAttributes only

## Impact Analysis

### ✅ No Impact
- Existing schema file behavior
- Processing when attributes are defined
- CLI command interface
- Integration with other features

### ✅ Improvements
- Clear sheet structure provided even with empty attributes
- Enhanced user understanding
- Improved template usability

## Usage Examples

### Before Fix
```bash
# Generate template with schema having empty attributes
rdetoolkit make-excelinvoice empty_schema.json -o template.xlsx
# Result: generalTerm, specificTerm sheets completely empty
```

### After Fix
```bash
# Generate template with same schema
rdetoolkit make-excelinvoice empty_schema.json -o template.xlsx
# Result: Each sheet contains header rows
# generalTerm sheet: term_id | key_name
# specificTerm sheet: sample_class_id | term_id | key_name
```

## Verification Steps

1. **Basic Operation Check**
   ```bash
   # Generate template with schema having empty attributes
   rdetoolkit make-excelinvoice tests/samplefile/invoice.schema_none_generalAttributes.json -o test_output.xlsx
   ```

2. **Existing Functionality Check**
   ```bash
   # Verify operation with normal schema
   rdetoolkit make-excelinvoice tests/samplefile/invoice.schema.json -o normal_output.xlsx
   ```

3. **Test Execution**
   ```bash
   pytest tests/test_invoicefile.py::test_empty_attributes_generates_header_only_sheets -v
   pytest tests/test_invoicefile.py::test_backward_compatibility_with_defined_attributes -v
   ```

## Review Points

### 🔍 Key Review Items

1. **Implementation Logic**: Proper conditional branching in `_add_sample_field()` method
2. **DataFrame Creation**: Correct column specification for empty DataFrames
3. **Test Coverage**: Appropriate testing of edge cases
4. **Backward Compatibility**: No impact on existing functionality

### 📋 Files to Review

- `src/rdetoolkit/invoicefile.py` (lines 403-408, 461-468)
- `tests/test_invoicefile.py` (new test cases)
- Structure of generated Excel files

## Related Issues

- Closes #144

## Notes

This fix significantly improves the usability of Excel invoice templates, ensuring users have a consistent experience regardless of schema content. The implementation is simple, maintainable, and has no impact on existing functionality.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Reset registered terms when attributes are empty

- Generate DataFrame with headers for empty sheets

- Add tests for empty and mixed attribute scenarios

- Validate CLI integration and backward compatibility


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invoicefile.py</strong><dd><code>Add header-only DataFrame generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/invoicefile.py

<li>Reset <code>registerd_general_terms</code> and <code>registerd_specific_terms</code> on empty <br>attributes<br> <li> Specify DataFrame <code>columns</code> for header-only sheet generation<br> <li> Preserve existing behavior for non-empty attributes


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/186/files#diff-416b6ece1abaceb864fcfcb5906af70fcfafd42b9393e331cac7e4cb0cf60668">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invoice.py</strong><dd><code>Add empty-attributes fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/fixtures/invoice.py

<li>Add <code>empty_attributes_schema</code> fixture for fully empty attributes<br> <li> Add <code>empty_general_attributes_schema</code> fixture for partial emptiness<br> <li> Generate temporary JSON schema files in <code>tmp_path</code>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/186/files#diff-e89650a315d94be477189d9e811d47dfa89ee1af5f8944372464aa17cb5f5a6a">+86/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_invoicefile.py</strong><dd><code>Add tests for empty attribute behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_invoicefile.py

<li>Test mixed empty and defined attribute behavior<br> <li> Verify backward compatibility with defined attributes<br> <li> Add CLI integration test for header-only sheets


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/186/files#diff-13e832840481bd3ec49476b2c3c8bbc72c883bea9ec973d39a6c17cc598e573f">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>