### PR TITLE
Fix StructuredError propagation in error handling pipeline

### DIFF
--- a/src/rdetoolkit/errors.py
+++ b/src/rdetoolkit/errors.py
@@ -191,7 +191,12 @@ def handle_and_exit_on_structured_error(e: StructuredError, logger: logging.Logg
         e (StructuredError): StructuredError instance
         logger (logging.Logger): Logger instance
     """
-    sys.stderr.write((e.traceback_info or "") + "\n")
+    if e.traceback_info:
+        sys.stderr.write(e.traceback_info + "\n")
+    else:
+        structured_error = handle_exception(e, verbose=True)
+        sys.stderr.write((structured_error.traceback_info or "") + "\n")
+
     write_job_errorlog_file(e.ecode, e.emsg)
     logger.exception(e.emsg)
     sys.exit(1)

--- a/src/rdetoolkit/errors.py
+++ b/src/rdetoolkit/errors.py
@@ -191,7 +191,7 @@ def handle_and_exit_on_structured_error(e: StructuredError, logger: logging.Logg
         e (StructuredError): StructuredError instance
         logger (logging.Logger): Logger instance
     """
-    if e.traceback_info:
+    if e.traceback_info is not None:
         sys.stderr.write(e.traceback_info + "\n")
     else:
         structured_error = handle_exception(e, verbose=True)

--- a/src/rdetoolkit/models/result.pyi
+++ b/src/rdetoolkit/models/result.pyi
@@ -11,6 +11,7 @@ class WorkflowExecutionStatus(BaseModel):
     error_message: str | None
     target: str | None
     stacktrace: str | None
+    exception_object: Exception | None
     @classmethod
     def format_run_id(cls, v: str) -> str: ...
 

--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -216,8 +216,7 @@ def _process_mode(
             if hasattr(status, 'exception_object'):
                 if isinstance(status.exception_object, StructuredError):
                     raise status.exception_object
-                else:
-                    logger.error(f"Non-StructuredError exception object encountered: {status.exception_object}")
+                logger.error(f"Non-StructuredError exception object encountered: {status.exception_object}")
             emsg = f"Processing failed in {mode} mode: {status.error_message}"
             raise StructuredError(emsg, status.error_code or 999)
 

--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -223,7 +223,6 @@ def _process_mode(
     except StructuredError:
         raise
     except Exception as e:
-        # その他の例外はStructuredErrorに変換
         emsg = f"Unexpected error in {mode} mode: {str(e)}"
         raise StructuredError(emsg, 999) from e
 

--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -213,8 +213,11 @@ def _process_mode(
             status = invoice_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
 
         if status.status == "failed":
-            if hasattr(status, 'exception_object') and isinstance(status.exception_object, StructuredError):
-                raise status.exception_object
+            if hasattr(status, 'exception_object'):
+                if isinstance(status.exception_object, StructuredError):
+                    raise status.exception_object
+                else:
+                    logger.error(f"Non-StructuredError exception object encountered: {status.exception_object}")
             emsg = f"Processing failed in {mode} mode: {status.error_message}"
             raise StructuredError(emsg, status.error_code or 999)
 

--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -188,29 +188,44 @@ def _process_mode(
     """
     error_info = None
 
-    if smarttable_file is not None:
-        mode = "SmartTableInvoice"
-        status = smarttable_invoice_mode_process(str(idx), srcpaths, rdeoutput_resource, smarttable_file, custom_dataset_function)
-    elif excel_invoice_files is not None:
-        mode = "Excelinvoice"
-        status = excel_invoice_mode_process(srcpaths, rdeoutput_resource, excel_invoice_files, idx, custom_dataset_function)
-    elif config.system.extended_mode is not None and config.system.extended_mode.lower() == "rdeformat":
-        mode = "rdeformat"
-        status = rdeformat_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
-    elif config.system.extended_mode is not None and config.system.extended_mode.lower() == "multidatatile":
-        mode = "MultiDataTile"
-        ignore_error = config.multidata_tile.ignore_errors if config.multidata_tile else False
-        with skip_exception_context(Exception, logger=logger, enabled=ignore_error) as error_info:
+    # 処理実行
+    try:
+        if smarttable_file is not None:
+            mode = "SmartTableInvoice"
+            status = smarttable_invoice_mode_process(str(idx), srcpaths, rdeoutput_resource, smarttable_file, custom_dataset_function)
+        elif excel_invoice_files is not None:
+            mode = "Excelinvoice"
+            status = excel_invoice_mode_process(srcpaths, rdeoutput_resource, excel_invoice_files, idx, custom_dataset_function)
+        elif config.system.extended_mode is not None and config.system.extended_mode.lower() == "rdeformat":
+            mode = "rdeformat"
+            status = rdeformat_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
+        elif config.system.extended_mode is not None and config.system.extended_mode.lower() == "multidatatile":
+            mode = "MultiDataTile"
+            ignore_error = config.multidata_tile.ignore_errors if config.multidata_tile else False
+            if ignore_error:
+                # ignore_errorが有効な場合のみ例外をキャッチ
+                with skip_exception_context(Exception, logger=logger, enabled=True) as error_info:
+                    status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
+                return status, error_info, mode
             status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
-    else:
-        mode = "Invoice"
-        status = invoice_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
+        else:
+            mode = "Invoice"
+            status = invoice_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
 
-    if (status.status == "failed" and not (mode == "MultiDataTile" and config.multidata_tile and config.multidata_tile.ignore_errors)):
-        emsg = f"Processing failed in {mode} mode: {status.error_message}"
-        raise Exception(emsg)
+        if status.status == "failed":
+            if hasattr(status, 'exception_object') and isinstance(status.exception_object, StructuredError):
+                raise status.exception_object
+            emsg = f"Processing failed in {mode} mode: {status.error_message}"
+            raise StructuredError(emsg, status.error_code or 999)
 
-    return status, error_info, mode
+        return status, error_info, mode
+
+    except StructuredError:
+        raise
+    except Exception as e:
+        # その他の例外はStructuredErrorに変換
+        emsg = f"Unexpected error in {mode} mode: {str(e)}"
+        raise StructuredError(emsg, 999) from e
 
 
 def run(*, custom_dataset_function: _CallbackType | None = None, config: Config | None = None) -> str:  # pragma: no cover


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes an issue where `StructuredError` exceptions raised within custom dataset functions decorated with `@catch_exception_with_message` were not properly propagated to the `job.failed` file. Instead of writing the custom error codes and messages, the system was always writing a generic error (code 999) with the message "Please check the logs and code, then try again."

## Problem

As reported in issue #203, when users decorated their custom functions with `@catch_exception_with_message` and raised a `StructuredError` with specific error codes and messages, these values were lost during exception handling. The error handling pipeline was converting `StructuredError` exceptions to generic exceptions at multiple points, causing the loss of custom error information.

## Solution

### 1. Pipeline Layer Changes
- Modified `Pipeline.execute()` to properly propagate `StructuredError` exceptions without converting them to `WorkflowExecutionStatus`
- Other exceptions continue to be converted to `WorkflowExecutionStatus` as before

### 2. Workflow Layer Changes  
- Refactored `_process_mode()` function to handle `StructuredError` propagation correctly
- When a process returns a failed status, the function now checks for the original exception object and re-raises it if it's a `StructuredError`
- Removed lambda expressions for better code readability and maintainability

### 3. Error Handler Improvements
- Enhanced `handle_and_exit_on_structured_error()` to use the same formatted stack trace functionality as `handle_generic_error()`
- This provides better debugging experience with simplified, readable stack traces including the fire emoji (🔥) marker

## Changes Made

### Modified Files
- `src/rdetoolkit/processing/pipeline.py`
  - Added `StructuredError` import
  - Modified exception handling in `execute()` method to propagate `StructuredError`
  
- `src/rdetoolkit/workflows.py`
  - Refactored `_process_mode()` to properly handle `StructuredError` propagation
  - Removed lambda expressions and simplified control flow
  
- `src/rdetoolkit/errors.py`
  - Enhanced `handle_and_exit_on_structured_error()` with formatted stack trace support

### Test Files
- `tests/test_exception.py`
  - Added test cases for `@catch_exception_with_message` with `StructuredError`
  - Added test cases for `handle_and_exit_on_structured_error` improvements
  
- `tests/test_workflow.py`
  - Added end-to-end test to verify proper error propagation to `job.failed`

## Testing

### Unit Tests
- ✅ `test_catch_exception_with_message_with_structured_error`: Verifies decorator behavior with StructuredError
- ✅ `test_catch_exception_with_message_with_generic_exception`: Verifies decorator behavior with generic exceptions
- ✅ `test_handle_and_exit_on_structured_error_with_traceback_info`: Tests improved stack trace handling
- ✅ `test_handle_and_exit_on_structured_error_without_traceback_info`: Tests stack trace generation

### Integration Tests
- ✅ `test_structured_error_propagation_in_workflow`: End-to-end test verifying error codes and messages are correctly written to `job.failed`

### Regression Tests
- ✅ All existing tests pass without modification
- ✅ No breaking changes to existing functionality
- ✅ Code quality checks (ruff) pass

## Expected Behavior After Fix

### Before
```python
@catch_exception_with_message(error_message="Dataset processing failed", error_code=50)
def dataset_function(srcpaths, resource_paths):
    raise StructuredError("error message in dataset()", 21)
```

`data/job.failed`:
```
ErrorCode=999
ErrorMessage=Error: Please check the logs and code, then try again.
```

### After
```python
@catch_exception_with_message(error_message="Dataset processing failed", error_code=50)
def dataset_function(srcpaths, resource_paths):
    raise StructuredError("error message in dataset()", 21)
```

`data/job.failed`:
```
ErrorCode=21
ErrorMessage=Error: error message in dataset()
```

## Impact

- No breaking changes to existing APIs
- Improved error handling and debugging experience
- Custom error codes and messages are now properly preserved throughout the error handling pipeline
- Better stack trace formatting for all `StructuredError` exceptions

## Related Issues

- Fixed #201 
- Fixed: #24  

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code has been commented where necessary
- [x] Tests have been added that prove the fix is effective
- [x] All new and existing tests pass
- [x] No new warnings introduced


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Propagate StructuredError without losing custom codes

- Enhance exit handler with existing traceback support

- Convert generic workflow errors to StructuredError

- Add comprehensive StructuredError propagation tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pipeline.py: Rethrow StructuredError in execute"]
  B["workflows.py: Convert and rethrow errors"]
  C["errors.py: Enhance StructuredError exit handler"]
  D["models/result.pyi: Add exception_object field"]
  E["tests/test_exception.py: Add decorator and handler tests"]
  F["tests/test_workflow.py: Add workflow propagation test"]
  A --> B
  B --> C
  B --> D
  C --> E
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.py</strong><dd><code>Enhance StructuredError exit handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/errors.py

<ul><li>Use existing traceback_info if available<br> <li> Generate formatted traceback when missing<br> <li> Maintain job.failed logging and exit behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-5e103e472efb744323aa5c1600372df58d7b7e4ede062858e94ba0d9af02ec00">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pipeline.py</strong><dd><code>Propagate StructuredError in pipeline execute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/processing/pipeline.py

<ul><li>Catch and rethrow StructuredError in execute<br> <li> Add exception_object field to success status</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-d4ce1f14c871ac3a75fc11a03d2059a56c42e683137dbace5f422679bb1da54a">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflows.py</strong><dd><code>Refactor workflow to rethrow StructuredError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/workflows.py

<ul><li>Wrap mode processing in try/except blocks<br> <li> Rethrow StructuredError on failed status<br> <li> Convert generic errors to StructuredError with code<br> <li> Simplify MultiDataTile ignore_errors logic</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-b2128aab32afd5b3f02c8b34e80d2310c175aee4134bfb3fb2d0dba0015f345e">+35/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>result.pyi</strong><dd><code>Add exception_object to result model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/models/result.pyi

- Add exception_object field to WorkflowExecutionStatus type


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-16d4141620c6ddd5fb80083e7db595d7edbe50f31b66a4a8a9a67dcbcc30e671">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_exception.py</strong><dd><code>Add tests for StructuredError decorator and handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_exception.py

<ul><li>Add tests for catch_exception_with_message decorator<br> <li> Test StructuredError and generic exception cases<br> <li> Verify handle_and_exit_on_structured_error branches</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-190a2e094cebe45f2deb6920e4570de1d12b8ff1cd8c105d4c6da1d14d4d7a63">+103/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_workflow.py</strong><dd><code>Add workflow StructuredError propagation test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_workflow.py

<ul><li>Add workflow StructuredError propagation test<br> <li> Validate job.failed uses inner error values<br> <li> Ensure decorator values are not written</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/209/files#diff-24e2d1e2ad448ca27676c50d54e09656ecf6f90781d9dad74b9dde4c195b8882">+88/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

