### PR TITLE
Develop/236 Initialize MultiDataTile status before returning from ignored errors

### DIFF
--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -200,6 +200,7 @@ def _process_mode(  # noqa: C901
         elif config.system.extended_mode is not None and config.system.extended_mode.lower() == "multidatatile":
             mode = "MultiDataTile"
             ignore_error = config.multidata_tile.ignore_errors if config.multidata_tile else False
+            status = None
             if ignore_error:
                 # ignore_errorが有効な場合のみ例外をキャッチ
                 with skip_exception_context(Exception, logger=logger, enabled=True) as error_info:


### PR DESCRIPTION
### **User description**
## Related Issue
- #236 

## Changes
<!--Describe the implementation details and changes made-->

- Fix a crash in MultiDataTile mode that occurred when `ignore_errors=True` suppressed a `StructuredError` raised by a custom dataset function.
- Initialize `status` before entering the `skip_exception_context` so the return statement can safely reference it even if the callback fails immediately.
- Document the regression scenario and the temporary mitigation steps for future follow-up work.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduce new graph plotting API with modular architecture
  - Add `csv2graph` and `plot_from_dataframe` as user-facing APIs
  - Implement flexible configuration via builder pattern
  - Support overlay and individual plotting strategies

- Add comprehensive unit tests for graph plotting components
  - Test configuration builder, normalizers, parsers, and renderers
  - Ensure legacy compatibility and edge case handling

- Implement Matplotlib-based renderer for static plots
  - Support direction-based coloring, legend, and axis configuration
  - Modularize rendering logic for overlay and individual plots

- Add robust column normalization and validation utilities
  - Handle flexible column specifications and error reporting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UserCode["User-facing API (csv2graph, plot_from_dataframe)"]
  ConfigBuilder["PlotConfigBuilder (config.py)"]
  Parsers["CSV/Data Parsers (parsers.py, parser_factory.py)"]
  Normalizers["Column Normalizers (normalizers.py)"]
  Strategies["Plotting Strategies (all_graphs.py, individual.py)"]
  Renderer["Matplotlib Renderer (matplotlib_renderer.py)"]
  Tests["Comprehensive Unit Tests (test_*.py)"]

  UserCode -- "builds config" --> ConfigBuilder
  UserCode -- "parses CSV/data" --> Parsers
  Parsers -- "normalize columns" --> Normalizers
  ConfigBuilder -- "provides PlotConfig" --> Strategies
  Normalizers -- "validate specs" --> Strategies
  Strategies -- "delegate rendering" --> Renderer
  Renderer -- "produces Figure/Result" --> UserCode
  Tests -- "cover all modules" --> UserCode
  Tests -- "cover all modules" --> ConfigBuilder
  Tests -- "cover all modules" --> Parsers
  Tests -- "cover all modules" --> Normalizers
  Tests -- "cover all modules" --> Strategies
  Tests -- "cover all modules" --> Renderer
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>csv2graph.py</strong><dd><code>Add modular CSV-to-graph plotting API and config builder</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-93c743c0d55c3fdd0ce7c9f06a19428754e7721aa5fdeba41ca1f2a087bdcb1d">+612/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>matplotlib_renderer.py</strong><dd><code>Implement Matplotlib-based renderer for static plots</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-fc44c32478847258857843282eca3c9b7d35c4578d5199f33449afd1cd43b1ca">+619/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>individual.py</strong><dd><code>Add strategy for individual series plotting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-43673a14140f87ef7622b19a0039ba8604e633ef93bb0cd8873e29ec13a28507">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test_config.py</strong><dd><code>Add unit tests for PlotConfigBuilder and config logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ac6e50e705ec4e318973c0643ec01acc1dd46905a3962a7ce943da358b82dbe1">+807/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_normalizers.py</strong><dd><code>Add comprehensive tests for column normalizers/validators</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-4d13febca2aec8ca3046e2dea23a182d67ad8e3bb88701d0b749a75ac231411d">+371/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_parsers.py</strong><dd><code>Add unit and integration tests for CSV/data parsers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-3eeb6d7fc63791833150731d2300eff1e2fa9e49364a25bdae72e7d9d9571cb6">+387/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_normalizers.py</strong><dd><code>Add additional tests for column normalization/validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-4fa17e5d5079ece090898a28cadbd39b5d484e8fc7e7b98e47f0f337e65bba85">+317/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>coverage_badge.yml</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-94d475259bc2bce58bafb7b64cb4f6378fc7a104b75c379644af9744fc9fb3c4">+19/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>coverage_pr_reports.yml</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-587f76c7e9b644604e943524e1de590f41b6993fff8786e9b9e200bfc5b3e7ff">+17/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pypi-release.yml</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-cd1f17b21b16e3d73b40849fa2eda95b55ec846d667fb026a98b0c50884b204a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.textlintrc.json</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-077fe4bee23e556f293f6718839b0d6a99376402aa372e2fb04fc1ce82a74efa">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+16/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>README_ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-43de4122a4a81b8e5a44e83c18887a33a680413d395e21ddaaf2fc3b3ece864c">+16/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-1aa3550609505ea0ba4e8de908f1a0b010424ff9ab5071c752473080fe8cb649">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-4e9c200ed630946bf59d9d737bc1e557921907022c9e249a7ecc6d8dbc1671ce">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>installation.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c03df636888f7fbd0dfe5614df38292008bfb9a945eca7495cbb7b428851148d">+33/-46</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>installation.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08e">+16/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>quick-start.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ddbd5a9a13dc15648d80264712df4a063f8bedaad3108d91929d38756b0f32bb">+16/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gen_config.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-0dbcd06b4385113001a4c24317503593f0873227ccc1866d09e5300e50e2e5cf">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gen_config.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-516c78ff76d1fd378b77f6eb653eec847d9c7db90c074229b20fd2ff471f8c75">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>csv2graph.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-6226723ac2258e584f8f5d0f0a6d12af69a4b3a436eda2f88cad4da5944714ea">+192/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-73c5d4831c88e6156c24e4ac465469aee679ff550ee1117c30cec7ca10f7263d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-a56bbb89cc073f719424763e55ff3975cb0b24a4f15698f4791f16fd7bf1d13e">+22/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>formatter.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-b01b49693324a7b5aadfec80414369fdcc6a4e1a04002f6b21c425d77ed5de90">+461/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>index.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-1c1f8415f2c07d2975e1e74403cb6efe930c398d94078ab7ed1ba14e923612ac">+317/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>masking.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-e48054a10dab7fae5b2219d815fda97cda071ef96d2c8e0ca50152dc850f0ffa">+449/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cli.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-74c884fe77ec441885048f5ff7ab2db9b5023c311a72d76c7e8ec045360969a7">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-78206f730a4dc971d08daed30369fe9ecd2980cebb092daa4402c9116739f232">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-69af7ff9f53c7ebffd19d319c3c88167e9cd9813c4a87d1666798ba358805411">+241/-154</a></td>

</tr>

<tr>
  <td><strong>config.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-58a67fff54b38d495606784cedc09df93f9b4eeeaad766643774d5a5f8b1ed38">+189/-102</a></td>

</tr>

<tr>
  <td><strong>file_folder_mode.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-2dfc8d8caa3e690393c092db8a3accff2eeb20a0ac970529ab0e0927be81edab">+35/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>magic_variable.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-4e519727cfc63464e015d9c2c0be22a53bde95e9b4c30c59fcecba7beb101a7a">+39/-165</a></td>

</tr>

<tr>
  <td><strong>magic_variable.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c7c5dfd8215f61d260d986ca709ebb666f13134c7a48d678df2ca2754e5163c7">+3/-180</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>metadata_definition_file.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-16db8044ee918d7a15b4c471ed3c42ed4ce2bb3b2f9901415677c3e580d75c82">+506/-279</a></td>

</tr>

<tr>
  <td><strong>metadata_definition_file.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-91572223fd23063d84f6cab2a0b0d216f85baf134526de13dc287d1902cc7e68">+489/-262</a></td>

</tr>

<tr>
  <td><strong>csv2graph.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-44af7a9f33cd106cd64e285ac79604d3bb0982b11f5bb0f35395f52ed045f1fe">+560/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>csv2graph.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-b0dea1e3df8473ee840eed67c050ac8d38ea1a67c79a29c32f97b1f9fb355295">+560/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>errorhandling.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-de7ac4289ab26e26d10de180e52ab5e1fbb0b6ace5ba321f0c0212e2e88e4235">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errorhandling.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c3332a7ea873b2f6b302b8fae6caa9f7b27b60775eab890f1eaf3911ee379214">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>traceback.en.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-1fddb7bcfbfa8c7d1e07a5c0a145ce594d57ae6d35232ce88b6448e38ffef027">+250/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>traceback.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-6e0f9dea7608f4d3b4e1dbbbac31b26075425ff681f21153bee1a5ebeefada0c">+250/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>structured-processing.ja.md</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-8af86fbd1539b32ed1c06d90fdaa20a378e6b6d2e7cbb549cd076fefa9d92760">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mkdocs.yml</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+54/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-b2b5edda308439d777cf4d737fac773062cf78befc70bfb9f5ebc4917296094f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cli.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-195949060ee252daba59aeeafa6384be4d1e76832b53a8f026fa1e372c887c81">+229/-7</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>csv2graph.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-0474efd1b65157667ef20b2a98231fb71367be28d8f65c619894a70dda80fb03">+154/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>csv2graph.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-2450d8054da8db92208213c1bf9350fd2486a535db6e36b8a61b2c5f1e206505">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gen_config.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-72569e5334bd08eaee108233feab06f71d36cca3793bc9a7078642a6053f41b7">+268/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>gen_config.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-3fe9b8aa39139192e656d5d73922ea85a30db94a1d3ede89363d45a9e61d41b0">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-b92f32302be54dd97e68cdd859dd1b1e03de9209d1a37d1cdd92bf4f79070b61">+33/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ff874588d76a018b0a6552d40fe7020d50b9cea28263b9eb149bf9560cdc57c7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>errors.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-5e103e472efb744323aa5c1600372df58d7b7e4ede062858e94ba0d9af02ec00">+95/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>errors.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-65c64abe45088e8b1940401a545faefcf034bf81345837e9c59cc45e43947893">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>graph.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-79534833c44993f1e31d6c085bd4e79422ed331a95273535e5c1a90326fcdcde">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-983f60ca5ce99b9eece8f1ef23dd3f8eae52a50d5c4d04d835cb6d377e367a6d">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-03cb093789395940352a246b9e21672ee7b92bfca58364477f7e4fd27353ada9">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-f8358afefb92601f5a94e6e4aafa43d7c067ba317e63cd9121ff143b719b1d70">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-1fa5a1244c7c87538286a0dedafe6e4725a33f935e9dd7000db15320abdeeb36">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-899e310a1c2605f4e669d2777158101b18090478a62b3db662014d4afaa4e060">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>csv2graph.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-6322bf57076abcf8b7a5f07474cef5b3f52b835c83f4492cb14ee6a11aa6ca5e">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-651dde579c13a686a45ac460e50f43bfd8841c795f67d641c13e10952ffdf393">+417/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c95a9c6097df19b41fa8f6f666d6061df3bc4c20e425de38526cc01754de62b2">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exceptions.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-51e91548fb453fd40119ea8b44d2eb55ac6bb28350a2458fcaf4d7d55ef56dc6">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exceptions.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-982b82c514bf7fad1cb53d8b17e0ffe2a94a54b0e8399891cb50ac55428c8b30">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>io.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-266f6b743d8aa1640d1fa9daf91fb47ea60dc83f3a2b9594f21364cffaad7ca0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-550842243bc7793714bbb8141114640bfcd94eb9f5d2b4c802c34c22cfe28d5b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ca80eb1def8b71e74690be18dda8674444c8f0ed36b964c6a4ae6544a7967690">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>file_writer.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-5e72af7682d200d6a2605a5b47d4040de55eb6ce4fb741115485ec6144b99c2c">+148/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>file_writer.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-5837b1577d2d043e9cea28f6e48b92abde24c02c77a1f31eddfbd62ba6cabea6">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>path_validator.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-a0d314ac9196eb5aff4970ef345d282377a9564415b255e6c0f6b2fba1af530b">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>path_validator.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-2f0b05e693161a6b080c29ad8379af138ca41e364ba002c10213b523315be72f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-d516c4ab8c2453ed369b9adf138e19bd5a7f8b1e385ba8725b2e977b1c38b3c5">+195/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>models.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-09ec7c65dcf3eccc23fbd91f394fddc5357d26890183993756f52e6b1d16800f">+87/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>normalizers.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-00fbaf34b9b697e848cdd15fb43e44485673b2f7a9ee960eeb8a39d738004a48">+309/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>normalizers.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-014e964691d3005344080cab0fc5be55698fab453914e4e0dc343c8fdd20d0bc">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parsers.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-91df02bd6a3013f746eed2c9eef2da5a220a273cbc6448f7a09bbbee9d968797">+277/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>parsers.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-9799c7056ade2a14a0996d3e97c8c5237ab42312f1d8a67c02fd67cba0b4c8ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-74be385572cdfbbe48f0b3bef38e7c7fb575f9c5da178b06381c57a130f94189">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-28f407247f3a19df730d31b173e38941d6addb153722c8c0f28c7bab6b728e4a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-a9cc05c9afa3230c10150680cdb8798c3f0700329402bf831fb5d5cf5873e46e">+303/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>base.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-9a86070e5dbae278ba7e6ad45bd38838e9909267519d31f84442d3d5d69b72e4">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>noheader_parser.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-92185a8b6109a0acf516b74549ce58fe7f0a700c09a50b032deb170b6a282c31">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>noheader_parser.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-22b37c9e1b1f03d9e2bb91f0e914d85f4d0f28335cd9cb34b8ec7b1634cfecfb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parser_factory.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-72c9a2aef54df9d1bcce5d30e48abfe0c356b56ea324b3e8a6a1a18dfd9f008b">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>parser_factory.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-a3abf7daa94ad17c7476e76472542935d85338ad8856ac7fc9e13cb4c183d95a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>standard_parser.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c052e0e72c285ea87ddb3c73042f1d7e92e9a5f2d5bc5a50ab3ac003d322b578">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>standard_parser.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-6ec1e31140e4dc5c7c8fc4112e7bdac082d92981112f4c1ceb4c1854dd935337">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transpose_parser.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-d6f9407b18ef49a5cee97047137628e12cdd6acea3926142002d13cada86977d">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transpose_parser.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-06dedf33ceea2c18ec183e600146df090131fdd58201d11e214bc040efc48c07">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>renderers.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-9bda92edcf60f3b658f3ce953d7b2f0a6a87f864487186a405f2481cd70eb6ac">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-983ddfaf9959702bd3e1b0415156d0066fd35ab4382f2f0fb58df41450e78137">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-0bef39abb1c5ed28663c6ed80b886f0be7bcfe97b03dedaeb53b55bf0148d10b">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ba29954b8970c76e2bdde8d6e8d91e8a1a617573070586774d8a57e95f933565">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-67824edd6a1ca9a6c744df4b7bd95665a6ed87a0bea5fb996f2f4b3c04116931">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>matplotlib_renderer.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-ceb4625a0a828e4f74afc84040872d72c21f5408b97114ca2ad4cd82bc2b5c4f">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plotly_renderer.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-c54a83b998bffef2022b93312223197f8756299623c2e9f6463d456512e8e750">+392/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>plotly_renderer.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-359b759d074391c9cc446839688d2cc5f6f0e88aa9a632eab96e87b713a08d3d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>strategies.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-cefc3a443a4896a3abd65ae514174dc7de5fb106dfe4a9db16277e86f7aa5e69">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-5038a2b2ce7886f549d8373b886b30dba0f11cd53baf6f55ea741a6ce5407e79">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-7fc96ae8fa539db1f7b402d804f47755ea813fd371c8c2b2c77a62202a9ee6ea">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>all_graphs.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-948f076c8f8d623822786c5cbf8212a17fd6e00b933aabb22914e9880e6cbdeb">+92/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>all_graphs.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-703a82bac706d9ef3e544c1453fe025f58bcee04fe6d62fdd68426d5516ba11e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-77e8e2a27bc0d194d18c1f1e85ad78c067243bc84bbe6657c3266fc2ffd7bb7c">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-9c667ccde824cac8de271fd62357f5b1ac6be4ce29cfc65c9dc4f6cddfb327ab">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dual_axis.py</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-7f622a08d6e75b91ca8cea3de29e6bdd16bb061cc280fa1603315e33635743ed">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dual_axis.pyi</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-5e4b3dd11c54518c34017365ba742915288dd47de1dc83023cc6761d7a31c2b6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/242/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

