### PR TITLE
Fix duplicate code block marker in Japanese development guide

### DIFF
--- a/docs/usage/structured_process/development_guide.ja.md
+++ b/docs/usage/structured_process/development_guide.ja.md
@@ -1217,8 +1217,6 @@ def my_xrd_func(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePat
 `xrd_plot`関数では、XRDデータのプロット画像を作成します。以下のように実装します。
 
 ```python
-
-```python
 def parse_ras_file(filepath: str | Path) -> tuple[dict[str, str], pd.DataFrame]:
     # ... 省略: 上記のparse_ras_file関数の内容をここに含める ...
     return metadata, df


### PR DESCRIPTION
### **User description**
- [x] Fix duplicate code block marker in Japanese development guide (Issue #276)
- [x] Create new branch with correct naming convention (docs/copilot/fix-docs-minor-issues)

## Summary
Fixed issue #276 by removing the duplicate ````python` code block marker in the Step4 section of the Japanese development guide. Created new branch `docs/copilot/fix-docs-minor-issues` (instead of `copilot/fix-docs-minor-issues`) to ensure GitHub Pages deployment CI runs when merged to main.

## Changes
- **File Modified**: `docs/usage/structured_process/development_guide.ja.md`
- **Lines Removed**: 2 (duplicate ````python` marker and blank line)
- **Location**: Step4: プロット画像の作成 section
- **Commit**: 32111d9


___

### **PR Type**
Documentation


___

### **Description**
- Removed duplicate code block marker in Japanese development guide

- Fixed formatting in Step4: プロット画像の作成 section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["development_guide.ja.md with duplicate code block marker"] -- "Remove extra marker" --> B["development_guide.ja.md with correct code block"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>development_guide.ja.md</strong><dd><code>Remove duplicate code block marker in Step4 section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/usage/structured_process/development_guide.ja.md

<ul><li>Removed an unnecessary duplicate code block marker<br> <li> Improved code block formatting in Step4 section</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/280/files#diff-21773ec702982711978395e0bcd9797543f90a23ae4c2fa9d65296b3bdb4b171">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

