### PR TITLE
docs: #274 Update quick-start documentation to match the latest workflow paths

### DIFF
--- a/docs/quick-start.en.md
+++ b/docs/quick-start.en.md
@@ -1,117 +1,155 @@
-# Experience RDEToolKit
+# RDEToolKit Quick Start
 
 ## Purpose
 
-This tutorial will help you execute your first structured processing using RDEToolKit and experience the basic workflow. The estimated time is approximately 15 minutes.
+This tutorial walks you through running your first structured processing job with RDEToolKit and experiencing the core workflow. The entire exercise takes about 15 minutes.
 
-Upon completion, you will be able to:
-- Understand the basic structure of RDE projects
-- Create custom structured processing functions
-- Execute structured processing and verify results
+By the end you will be able to:
+
+- Understand the basic structure of an RDE project
+- Build a custom structured processing function
+- Execute the structured processing flow and review the results
 
 ## 1. Create a Project
 
 ### Purpose
-Create a project directory for RDE structured processing and prepare the necessary file structure.
+
+Create a project directory for RDE structured processing.
 
 ### Code to Execute
 
 === "Unix/macOS"
     ```bash title="terminal"
-    # Create project directory
+    # Create the project directory
     mkdir my-rde-project
     cd my-rde-project
-
-    # Create necessary directories
-    mkdir -p data/inputdata
-    mkdir -p tasksupport
-    mkdir -p modules
     ```
 
 === "Windows"
     ```cmd title="command_prompt"
-    # Create project directory
+    # Create the project directory
     mkdir my-rde-project
     cd my-rde-project
-
-    # Create necessary directories
-    mkdir data\inputdata
-    mkdir tasksupport
-    mkdir modules
     ```
-
-### Expected Result
-The following directory structure will be created:
-```
-my-rde-project/
-├── data/
-│   └── inputdata/
-├── tasksupport/
-└── modules/
-```
 
 ## 2. Define Dependencies
 
 ### Purpose
-Define the Python packages to be used in the project.
+Declare the Python packages required for the project.
+
+### Install RDEToolKit
+
+=== "Unix/macOS"
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install "rdetoolkit>=1.4.0"
+    ```
+
+=== "Windows"
+    ```powershell
+    python -m venv .venv
+    .\.venv\Scripts\Activate.ps1
+    pip install "rdetoolkit>=1.4.0"
+    ```
+
+### Expected Result
+
+Run `pip list` to confirm that `rdetoolkit` is installed.
+
+```bash
+$ pip list
+Package                   Version
+------------------------- -----------------
+rdetoolkit                1.4.0
+```
+
+## 3. Create the Project Structure
+
+### Purpose
+
+Generate the scaffolded directory layout for structured processing.
 
 ### Code to Execute
 
-```text title="requirements.txt"
-rdetoolkit>=1.0.0
+```bash
+rdetoolkit init
 ```
 
 ### Expected Result
-The `requirements.txt` file is created with RDEToolKit dependencies defined.
 
-## 3. Create Custom Structuring Processing
+```bash
+Ready to develop a structured program for RDE.
+Created: /Users/user1/my-rde-project/my-rde-project/container/requirements.txt
+Created: /Users/user1/my-rde-project/my-rde-project/container/Dockerfile
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/invoice/invoice.json
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/tasksupport/invoice.schema.json
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/tasksupport/metadata-def.json
+Created: /Users/user1/my-rde-project/my-rde-project/templates/tasksupport/invoice.schema.json
+Created: /Users/user1/my-rde-project/my-rde-project/templates/tasksupport/metadata-def.json
+Created: /Users/user1/my-rde-project/my-rde-project/input/invoice/invoice.json
+
+Check the folder: /Users/user1/my-rde-project/my-rde-project
+```
+
+## 4. Create Custom Structured Processing
 
 ### Purpose
-Create a custom function containing data processing logic.
 
-### Code to Execute
+Implement a custom function that contains your data processing logic.
 
-```python title="modules/process.py"
-from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
+### File to Create
+
+Create `container/modules/process.py` with the following content.
+
+```python title="container/modules/process.py"
+from pathlib import Path
 import json
 import os
 
-def display_message(message):
-    """Helper function to display messages"""
+from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
+
+
+def display_message(message: str) -> None:
+    """Helper function to display messages."""
     print(f"[INFO] {message}")
 
-def create_sample_metadata(resource_paths):
-    """Create sample metadata"""
+
+def create_sample_metadata(srcpaths: RdeInputDirPaths) -> None:
+    """Create sample metadata."""
     metadata = {
         "title": "Sample Dataset",
         "description": "RDEToolKit tutorial sample",
         "created_at": "2024-01-01",
-        "status": "processed"
+        "status": "processed",
     }
 
     # Save metadata file
-    metadata_path = os.path.join(resource_paths.tasksupport, "sample_metadata.json")
-    with open(metadata_path, 'w', encoding='utf-8') as f:
+    metadata_path = Path(srcpaths.tasksupport) / "sample_metadata.json"
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    with metadata_path.open("w", encoding="utf-8") as f:
         json.dump(metadata, f, ensure_ascii=False, indent=2)
 
     display_message(f"Metadata saved: {metadata_path}")
 
-def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
+
+def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath) -> None:
     """
-    Main structured processing function
+    Main structured processing function.
 
     Args:
-        srcpaths: Input file path information
-        resource_paths: Output resource path information
+        srcpaths: Input file path information.
+        resource_paths: Output resource path information.
     """
     display_message("Starting structured processing")
 
     # Display input path information
     display_message(f"Input data directory: {srcpaths.inputdata}")
-    display_message(f"Output resource directory: {resource_paths.root}")
+    display_message(f"Structured data output directory: {resource_paths.struct}")
+    display_message(f"Metadata output directory: {resource_paths.meta}")
 
     # Create sample metadata
-    create_sample_metadata(resource_paths)
+    create_sample_metadata(srcpaths)
 
     # Display list of input files
     if os.path.exists(srcpaths.inputdata):
@@ -123,23 +161,24 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
     display_message("Structured processing completed")
 ```
 
-### Expected Result
-The `modules/process.py` file is created with structured processing logic defined.
-
-## 4. Create Main Script
+## 5. Create the Main Script
 
 ### Purpose
-Create an entry point to launch the RDEToolKit workflow.
 
-### Code to Execute
+Provide the entry point that launches the RDEToolKit workflow.
+
+### File to Update
+
+Replace the contents of `container/main.py` with the following.
 
 ```python title="main.py"
 import rdetoolkit
 
 from modules import process
 
-def main():
-    """Main execution function"""
+
+def main() -> str:
+    """Main execution function."""
     print("=== RDEToolKit Tutorial ===")
 
     # Execute RDE structured processing
@@ -151,108 +190,129 @@ def main():
 
     return result
 
+
 if __name__ == "__main__":
     main()
 ```
 
-### Expected Result
-The `main.py` file is created and ready to execute structured processing.
-
-## 5. Prepare Sample Data
+## 6. Prepare Sample Data
 
 ### Purpose
-Create sample data to test the structured processing.
 
-### Code to Execute
+Create sample data (`data/inputdata/sample_data.txt`) to test the structured processing workflow.
 
-```text title="data/inputdata/sample_data.txt"
+### File to Create
+
+```text title="container/data/inputdata/sample_data.txt"
 Sample Research Data
 ====================
 
-This is a sample data file for RDEToolKit tutorial.
+This is a sample data file for the RDEToolKit tutorial.
 Created: 2024-01-01
 Type: Text Data
 Status: Ready for processing
 ```
 
-### Expected Result
-The `data/inputdata/sample_data.txt` file is created with sample data ready for processing.
-
-## 6. Execute Structuring Processing
+## 7. Run Structured Processing
 
 ### Purpose
-Execute RDE structured processing with the created project and verify its operation.
+Execute the structured processing workflow and verify that the project works correctly.
 
 ### Code to Execute
 
-```bash title="terminal"
-# Install dependencies
-pip install -r requirements.txt
+Move into the same directory as `data` and run `main.py`.
 
-# Execute structured processing
+```bash title="terminal"
+# Run structured processing
+cd container
 python main.py
 ```
 
 ### Expected Result
 
-Output similar to the following will be displayed:
+The execution prints output similar to the following:
 
 ```
 === RDEToolKit Tutorial ===
 [INFO] Starting structured processing
-[INFO] Input data directory: /path/to/my-rde-project/data/inputdata
-[INFO] Output resource directory: /path/to/my-rde-project
-[INFO] Metadata saved: /path/to/my-rde-project/tasksupport/sample_metadata.json
+[INFO] Input data directory: data/inputdata
+[INFO] Structured data output directory: data/structured
+[INFO] Metadata output directory: data/meta
+[INFO] Metadata saved: data/tasksupport/sample_metadata.json
 [INFO] Number of input files: 1
 [INFO]   - sample_data.txt
 [INFO] Structured processing completed
 
 === Processing Results ===
-Execution status: {'statuses': [{'run_id': '0000', 'title': 'sample-dataset', 'status': 'success', ...}]}
+Execution status: {
+  "statuses": [
+    {
+      "run_id": "0000",
+      "title": "toy dataset",
+      "status": "success",
+      "mode": "invoice",
+      "error_code": null,
+      "error_message": null,
+      "target": "data/inputdata",
+      "stacktrace": null
+    }
+  ]
+}
 ```
 
-## 7. Verify Results
+## 8. Review the Results
 
-### Purpose
-Verify the execution results and file generation of structured processing.
+Inspect the `data` directory.
 
-### Code to Execute
-
-```bash title="terminal"
-# Check generated file structure
-find . -type f -name "*.json" | head -10
+```bash
+data
+├── attachment
+├── inputdata
+│   └── sample_data.txt
+├── invoice
+│   └── invoice.json
+├── invoice_patch
+├── logs
+│   └── rdesys.log
+├── main_image
+├── meta
+├── nonshared_raw
+│   └── sample_data.txt
+├── other_image
+├── raw
+├── structured
+├── tasksupport
+│   ├── invoice.schema.json
+│   ├── metadata-def.json
+│   └── sample_metadata.json
+├── temp
+└── thumbnail
 ```
-
-### Expected Result
-
-You can verify that files like the following have been generated:
-- `tasksupport/sample_metadata.json` - Created metadata file
-- `raw/` or `nonshared_raw/` - Copy of input files (depending on configuration)
 
 ## Congratulations!
 
-You have completed your first structured processing using RDEToolKit.
+You have successfully completed your first structured processing flow with RDEToolKit.
 
 ### What You Accomplished
 
-✅ Created basic RDE project structure
-✅ Implemented custom structured processing function
-✅ Executed structured processing workflow
-✅ Learned how to verify processing results
+✅ Created the basic structure of an RDE project  
+✅ Implemented a custom structured processing function  
+✅ Ran the structured processing workflow  
+✅ Learned how to validate the processing results
 
-### Important Concepts Learned
+### Key Concepts Learned
 
-- **Project Structure**: Roles of `data/inputdata/`, `tasksupport/`, `modules/`
+- **Project Structure**: Roles of `data/inputdata/`, `data/tasksupport/`, and `modules/`
 - **Custom Functions**: How to use `RdeInputDirPaths` and `RdeOutputResourcePath`
 - **Workflow Execution**: Basic usage of `rdetoolkit.workflows.run()`
 
 ## Next Steps
 
-To learn more in detail:
+Deepen your understanding with the following resources:
 
-1. [Structuring Processing Concepts](user-guide/structured-processing.en.md) - Detailed understanding of processing flow
-2. [Configuration File](user-guide/config.en.md) - How to customize behavior
-3. [API Reference](api/index.en.md) - Check all available features
+1. [Structuring Processing Concepts](user-guide/structured-processing.en.md) – Learn the detailed flow
+2. [Configuration Guide](user-guide/config.en.md) – Customize runtime behavior
+3. [API Reference](api/index.en.md) – Explore the full feature set
 
 !!! tip "Next Practice"
-    Try more complex structured processing using actual research data. It's important to select the appropriate processing mode based on the type of data.
+    Try processing real research data to explore more advanced scenarios. Choose the processing mode that best fits your data type.

--- a/docs/quick-start.ja.md
+++ b/docs/quick-start.ja.md
@@ -23,11 +23,6 @@ RDE構造化処理用のプロジェクトディレクトリを作成し、必�
     # プロジェクトディレクトリを作成
     mkdir my-rde-project
     cd my-rde-project
-
-    # 必要なディレクトリを作成
-    mkdir -p data/inputdata
-    mkdir -p tasksupport
-    mkdir -p modules
     ```
 
 === "Windows"
@@ -35,54 +30,89 @@ RDE構造化処理用のプロジェクトディレクトリを作成し、必�
     # プロジェクトディレクトリを作成
     mkdir my-rde-project
     cd my-rde-project
-
-    # 必要なディレクトリを作成
-    mkdir data\inputdata
-    mkdir tasksupport
-    mkdir modules
     ```
-
-### 期待される結果
-以下のディレクトリ構造が作成されます：
-```
-my-rde-project/
-├── data/
-│   └── inputdata/
-├── tasksupport/
-└── modules/
-```
 
 ## 2. 依存関係を定義する
 
 ### 目的
 プロジェクトで使用するPythonパッケージを定義します。
 
-### 実行するコード
+### rdetoolkitをインストールする
 
-```text title="requirements.txt"
-rdetoolkit>=1.0.0
+=== "Unix/macOS"
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install "rdetoolkit>=1.4.0"
+    ```
+
+=== "Windows"
+    ```cmd
+    python -m venv .venv
+    .venv\Scripts\Activate.ps1
+    pip install "rdetoolkit>=1.4.0"
+    ```
+
+### 期待される結果
+
+`pip list`コマンドで`rdetoolkit`がインストールされていることを確認できます。
+
+```bash
+$ pip list
+Package                   Version
+------------------------- -----------------
+rdetoolkit                1.4.0
+```
+
+## 3. プロジェクト構造を作成する
+
+### 目的
+
+プロジェクトの基本的なディレクトリ構造を作成します。
+
+### 実行するコード
+```bash
+rdetoolkit init
 ```
 
 ### 期待される結果
-`requirements.txt`ファイルが作成され、RDEToolKitの依存関係が定義されます。
+
+```bash
+Ready to develop a structured program for RDE.
+Created: /Users/user1/my-rde-project/my-rde-project/container/requirements.txt
+Created: /Users/user1/my-rde-project/my-rde-project/container/Dockerfile
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/invoice/invoice.json
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/tasksupport/invoice.schema.json
+Created: /Users/user1/my-rde-project/my-rde-project/container/data/tasksupport/metadata-def.json
+Created: /Users/user1/my-rde-project/my-rde-project/templates/tasksupport/invoice.schema.json
+Created: /Users/user1/my-rde-project/my-rde-project/templates/tasksupport/metadata-def.json
+Created: /Users/user1/my-rde-project/my-rde-project/input/invoice/invoice.json
+
+Check the folder: /Users/user1/my-rde-project/my-rde-project
+```
 
 ## 3. カスタム構造化処理を作成する
 
 ### 目的
+
 データ処理のロジックを含むカスタム関数を作成します。
 
-### 実行するコード
+### 作成するファイル
 
-```python title="modules/process.py"
-from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
+`container/modules/process.py`を以下のように作成します。
+
+```python title="container/modules/process.py"
+from pathlib import Path
 import json
 import os
+
+from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
 
 def display_message(message):
     """メッセージを表示する補助関数"""
     print(f"[INFO] {message}")
 
-def create_sample_metadata(resource_paths):
+def create_sample_metadata(srcpaths: RdeInputDirPaths):
     """サンプルメタデータを作成する"""
     metadata = {
         "title": "Sample Dataset",
@@ -92,8 +122,9 @@ def create_sample_metadata(resource_paths):
     }
 
     # メタデータファイルを保存
-    metadata_path = os.path.join(resource_paths.tasksupport, "sample_metadata.json")
-    with open(metadata_path, 'w', encoding='utf-8') as f:
+    metadata_path = Path(srcpaths.tasksupport) / "sample_metadata.json"
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    with metadata_path.open('w', encoding='utf-8') as f:
         json.dump(metadata, f, ensure_ascii=False, indent=2)
 
     display_message(f"メタデータを保存しました: {metadata_path}")
@@ -110,10 +141,11 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
 
     # 入力パス情報を表示
     display_message(f"入力データディレクトリ: {srcpaths.inputdata}")
-    display_message(f"出力リソースディレクトリ: {resource_paths.root}")
+    display_message(f"構造化データ出力ディレクトリ: {resource_paths.struct}")
+    display_message(f"メタデータ出力ディレクトリ: {resource_paths.meta}")
 
     # サンプルメタデータを作成
-    create_sample_metadata(resource_paths)
+    create_sample_metadata(srcpaths)
 
     # 入力ファイルの一覧を表示
     if os.path.exists(srcpaths.inputdata):
@@ -125,15 +157,17 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
     display_message("構造化処理が完了しました")
 ```
 
-### 期待される結果
-`modules/process.py`ファイルが作成され、構造化処理のロジックが定義されます。
-
 ## 4. メインスクリプトを作成する
 
 ### 目的
+
 RDEToolKitのワークフローを起動するエントリーポイントを作成します。
 
-### 実行するコード
+### 作成するファイル
+
+`container/main.py` を以下のように書き換えます。
+
+
 
 ```python title="main.py"
 import rdetoolkit
@@ -157,17 +191,15 @@ if __name__ == "__main__":
     main()
 ```
 
-### 期待される結果
-`main.py`ファイルが作成され、構造化処理を実行する準備が整います。
-
 ## 5. サンプルデータを準備する
 
 ### 目的
-構造化処理をテストするためのサンプルデータを作成します。
 
-### 実行するコード
+構造化処理をテストするためのサンプルデータ(`data/inputdata/sample_data.txt`)を作成します。
 
-```text title="data/inputdata/sample_data.txt"
+### 作成するファイル
+
+```text title="container/data/inputdata/sample_data.txt"
 Sample Research Data
 ====================
 
@@ -177,9 +209,6 @@ Type: Text Data
 Status: Ready for processing
 ```
 
-### 期待される結果
-`data/inputdata/sample_data.txt`ファイルが作成され、処理対象のサンプルデータが準備されます。
-
 ## 6. 構造化処理を実行する
 
 ### 目的
@@ -187,11 +216,11 @@ Status: Ready for processing
 
 ### 実行するコード
 
-```bash title="terminal"
-# 依存関係をインストール
-pip install -r requirements.txt
+dataディレクトリと同じディレクトリに移動しmain.pyを実行します。
 
+```bash title="terminal"
 # 構造化処理を実行
+cd container
 python main.py
 ```
 
@@ -202,34 +231,59 @@ python main.py
 ```
 === RDEToolKit チュートリアル ===
 [INFO] 構造化処理を開始します
-[INFO] 入力データディレクトリ: /path/to/my-rde-project/data/inputdata
-[INFO] 出力リソースディレクトリ: /path/to/my-rde-project
-[INFO] メタデータを保存しました: /path/to/my-rde-project/tasksupport/sample_metadata.json
+[INFO] 入力データディレクトリ: data/inputdata
+[INFO] 構造化データ出力ディレクトリ: data/structured
+[INFO] メタデータ出力ディレクトリ: data/meta
+[INFO] メタデータを保存しました: data/tasksupport/sample_metadata.json
 [INFO] 入力ファイル数: 1
 [INFO]   - sample_data.txt
 [INFO] 構造化処理が完了しました
 
 === 処理結果 ===
-実行ステータス: {'statuses': [{'run_id': '0000', 'title': 'sample-dataset', 'status': 'success', ...}]}
+実行ステータス: {
+  "statuses": [
+    {
+      "run_id": "0000",
+      "title": "toy dataset",
+      "status": "success",
+      "mode": "invoice",
+      "error_code": null,
+      "error_message": null,
+      "target": "data/inputdata",
+      "stacktrace": null
+    }
+  ]
+}
 ```
 
 ## 7. 結果を確認する
 
-### 目的
-構造化処理の実行結果とファイル生成を確認します。
+dataディレクトリを確認してください。
 
-### 実行するコード
-
-```bash title="terminal"
-# 生成されたファイル構造を確認
-find . -type f -name "*.json" | head -10
+```bash
+data
+├── attachment
+├── inputdata
+│   └── sample_data.txt
+├── invoice
+│   └── invoice.json
+├── invoice_patch
+├── logs
+│   └── rdesys.log
+├── main_image
+├── meta
+├── nonshared_raw
+│   └── sample_data.txt
+├── other_image
+├── raw
+├── structured
+├── tasksupport
+│   ├── invoice.schema.json
+│   ├── metadata-def.json
+│   └── sample_metadata.json
+├── temp
+└── thumbnail
 ```
-
-### 期待される結果
-
-以下のようなファイルが生成されていることを確認できます：
-- `tasksupport/sample_metadata.json` - 作成したメタデータファイル
-- `raw/` または `nonshared_raw/` - 入力ファイルのコピー（設定による）
 
 ## おめでとうございます！
 
@@ -244,7 +298,7 @@ RDEToolKitを使用した最初の構造化処理が完了しました。
 
 ### 学んだ重要な概念
 
-- **プロジェクト構造**: `data/inputdata/`, `tasksupport/`, `modules/`の役割
+- **プロジェクト構造**: `data/inputdata/`, `data/tasksupport/`, `modules/`の役割
 - **カスタム関数**: `RdeInputDirPaths`と`RdeOutputResourcePath`の使用方法
 - **ワークフロー実行**: `rdetoolkit.workflows.run()`の基本的な使い方
 


### PR DESCRIPTION
### **User description**
## Related Issue
- Fixes #274

## Changes
- Align both quick-start guides so they create `data/tasksupport/` and reflect the current directory layout.
- Update the dependency example to `rdetoolkit>=1.4.0` and modernize the sample code and expected output paths.
- Record the documentation updates in `local/develop/issue_274.md` for traceability.

## Out of Scope
- Any automation or CLI tooling changes beyond the quick-start content adjustments.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Documentation


___

### **Description**
- Fully update English and Japanese quick-start guides for RDEToolKit
  - Align directory structure, dependency installation, and workflow steps
  - Modernize sample code and expected outputs to match latest toolkit version
  - Clarify and expand step-by-step instructions and file locations

- Improve clarity and accuracy of code samples and explanations

- Add explicit instructions for dependency management and project initialization

- Update result verification and next steps sections for user guidance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldDocs["Outdated Quick Start Docs"] -- "replace & expand" --> newDocs["Updated Quick Start Docs (EN/JA)"]
  newDocs -- "clarify steps" --> structure["Project Structure & Initialization"]
  newDocs -- "modernize code" --> code["Sample Code & File Paths"]
  newDocs -- "update outputs" --> outputs["Expected Results & Verification"]
  newDocs -- "guide users" --> next["Next Steps & Concepts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quick-start.en.md</strong><dd><code>Major update to English quick-start documentation for RDEToolKit</code></dd></summary>
<hr>

docs/quick-start.en.md

<ul><li>Overhauled quick-start guide for latest RDEToolKit workflow<br> <li> Updated directory structure, dependency installation, and sample code<br> <li> Clarified file locations, expected outputs, and verification steps<br> <li> Improved explanations and added explicit next steps</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/281/files#diff-ddbd5a9a13dc15648d80264712df4a063f8bedaad3108d91929d38756b0f32bb">+166/-106</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>quick-start.ja.md</strong><dd><code>Major update to Japanese quick-start documentation for RDEToolKit</code></dd></summary>
<hr>

docs/quick-start.ja.md

<ul><li>Fully revised Japanese quick-start guide to match latest workflow<br> <li> Synchronized instructions, code, and structure with English version<br> <li> Updated sample code, directory layout, and result verification<br> <li> Enhanced clarity and user guidance throughout</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/281/files#diff-6261828970e101108b9d8977d44d44ad3a4ce60cd8d5b279c8ab27123e1872f7">+119/-65</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

