### PR TITLE
Revert "fixed: #273 Fix MultiDataTile ignore_errors handling to preserve StructuredError details"

### DIFF
--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -206,8 +206,6 @@ def _process_mode(  # noqa: C901 PLR0912
                 with skip_exception_context(Exception, logger=logger, enabled=True) as error_info:
                     status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
                 if status is None:
-                    if any(value is not None for value in error_info.values()):
-                        return status, error_info, mode
                     emsg = "MultiDataTile mode did not return a workflow status"
                     raise StructuredError(emsg)
                 return status, error_info, mode

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -6,10 +6,8 @@ import pytest
 import yaml
 import toml
 
-from rdetoolkit.exceptions import StructuredError
-from rdetoolkit.workflows import run, _process_mode, _create_error_status
+from rdetoolkit.workflows import run
 from rdetoolkit.models.config import Config, SystemSettings, MultiDataTileSettings
-from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
 
 
 @pytest.fixture
@@ -120,79 +118,6 @@ def test_run_config_file_multifile_mode(
     assert config.system.save_thumbnail_image is False
     assert config.system.magic_variable is False
     assert config.multidata_tile.ignore_errors is False
-
-
-def test_multidatatitle_ignore_errors_collects_structured_error(monkeypatch, tmp_path):
-    """ignore_errors=True の MultiDataTile で StructuredError が捕捉され、ジョブが継続できることを確認する"""
-    input_dir = tmp_path / "inputdata"
-    tasksupport_dir = tmp_path / "tasksupport"
-    invoice_dir = tmp_path / "invoice"
-    for directory in (input_dir, tasksupport_dir, invoice_dir):
-        directory.mkdir(parents=True, exist_ok=True)
-
-    raw_file = input_dir / "sample.txt"
-    raw_file.write_text("dummy", encoding="utf-8")
-    (tasksupport_dir / "invoice.schema.json").write_text("{}", encoding="utf-8")
-    (tasksupport_dir / "invoice_org.json").write_text("{}", encoding="utf-8")
-
-    rdeoutput_resource = RdeOutputResourcePath(
-        raw=tmp_path / "raw",
-        nonshared_raw=tmp_path / "nonshared_raw",
-        rawfiles=(raw_file,),
-        struct=tmp_path / "struct",
-        main_image=tmp_path / "main_image",
-        other_image=tmp_path / "other_image",
-        meta=tmp_path / "meta",
-        thumbnail=tmp_path / "thumbnail",
-        logs=tmp_path / "logs",
-        invoice=invoice_dir,
-        invoice_schema_json=tasksupport_dir / "invoice.schema.json",
-        invoice_org=tasksupport_dir / "invoice_org.json",
-        temp=tmp_path / "temp",
-    )
-
-    config = Config(
-        system=SystemSettings(extended_mode="MultiDataTile", save_raw=True, save_thumbnail_image=False, magic_variable=False),
-        multidata_tile=MultiDataTileSettings(ignore_errors=True),
-    )
-
-    srcpaths = RdeInputDirPaths(
-        inputdata=input_dir,
-        invoice=invoice_dir,
-        tasksupport=tasksupport_dir,
-        config=config,
-    )
-
-    error_message = "温度数とサイクル数が不一致です。invoiceで1個の温度を指定してください。"
-    structured_error = StructuredError(error_message, ecode=1060)
-
-    def raise_structured_error(*_args, **_kwargs):
-        raise structured_error
-
-    monkeypatch.setattr("rdetoolkit.workflows.multifile_mode_process", raise_structured_error)
-
-    status, error_info, mode = _process_mode(
-        idx=0,
-        srcpaths=srcpaths,
-        rdeoutput_resource=rdeoutput_resource,
-        config=config,
-        excel_invoice_files=None,
-        smarttable_file=None,
-        custom_dataset_function=None,
-        logger=None,
-    )
-
-    assert status is None
-    assert mode == "MultiDataTile"
-    assert error_info["code"] == 1060
-    assert error_message in (error_info["message"] or "")
-    assert "StructuredError" in (error_info["stacktrace"] or "")
-
-    failure_status = _create_error_status(0, error_info, rdeoutput_resource, mode)
-    assert failure_status.status == "failed"
-    assert failure_status.error_code == 1060
-    assert error_message in (failure_status.error_message or "")
-    assert str(raw_file) in (failure_status.target or "")
 
 
 def test_run_empty_config(


### PR DESCRIPTION
### **User description**
Reverts nims-mdpf/rdetoolkit#279


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Revert MultiDataTile ignore_errors StructuredError preservation fix

- Remove regression test for ignore_errors StructuredError handling

- Restore previous error handling logic in workflows.py


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflows_py["workflows.py: MultiDataTile ignore_errors handling"] -- "revert StructuredError preservation" --> workflows_py
  test_workflow_py["test_workflow.py: regression test"] -- "remove StructuredError ignore_errors test" --> test_workflow_py
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflows.py</strong><dd><code>Revert StructuredError preservation in MultiDataTile ignore_errors</code></dd></summary>
<hr>

src/rdetoolkit/workflows.py

<ul><li>Remove logic returning StructuredError details for ignore_errors<br> <li> Restore previous error raising behavior for MultiDataTile mode</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/282/files#diff-b2128aab32afd5b3f02c8b34e80d2310c175aee4134bfb3fb2d0dba0015f345e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workflow.py</strong><dd><code>Remove regression test for ignore_errors StructuredError handling</code></dd></summary>
<hr>

tests/test_workflow.py

<ul><li>Remove regression test for MultiDataTile ignore_errors StructuredError<br> <li> Restore test file to previous state without ignore_errors test</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/282/files#diff-24e2d1e2ad448ca27676c50d54e09656ecf6f90781d9dad74b9dde4c195b8882">+1/-76</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

