### PR TITLE
fixed: #273 Fix MultiDataTile ignore_errors handling to preserve StructuredError details

### DIFF
--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -206,6 +206,8 @@ def _process_mode(  # noqa: C901 PLR0912
                 with skip_exception_context(Exception, logger=logger, enabled=True) as error_info:
                     status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)
                 if status is None:
+                    if any(value is not None for value in error_info.values()):
+                        return status, error_info, mode
                     emsg = "MultiDataTile mode did not return a workflow status"
                     raise StructuredError(emsg)
                 return status, error_info, mode


### PR DESCRIPTION
### **User description**
## Related Issue
- Issue #273

## Changes
- Adjust `_process_mode` so MultiDataTile with `ignore_errors=True` returns captured StructuredError details instead of raising a new error.
- Add a regression test that exercises the MultiDataTile ignore-errors path and verifies failure status generation.
- Document the remediation plan and verification steps in `develop/issue_273.md`.

## Out of Scope
- Additional MultiDataTile scenarios beyond the ignore-errors regression.
- Broader workflow error-handling improvements outside the targeted branch.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts
- [x] `pytest tests/test_workflow.py::test_multidatatitle_ignore_errors_collects_structured_error`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix MultiDataTile ignore_errors to preserve StructuredError details
  - Returns captured StructuredError info instead of raising new error

- Add regression test for MultiDataTile ignore_errors path
  - Verifies StructuredError is captured and status is generated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["_process_mode MultiDataTile with ignore_errors=True"] -- "StructuredError occurs" --> B["StructuredError details captured in error_info"]
  B -- "status is None & error_info present" --> C["Return status, error_info, mode"]
  C -- "Test: simulate StructuredError" --> D["Verify error_info and failure status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflows.py</strong><dd><code>Fix StructuredError handling in MultiDataTile ignore_errors mode</code></dd></summary>
<hr>

src/rdetoolkit/workflows.py

<ul><li>Fixes logic to return StructuredError details if present in error_info<br> <li> Avoids raising new error when StructuredError is captured in <br>MultiDataTile mode</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/283/files#diff-b2128aab32afd5b3f02c8b34e80d2310c175aee4134bfb3fb2d0dba0015f345e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workflow.py</strong><dd><code>Add regression test for MultiDataTile StructuredError handling</code></dd></summary>
<hr>

tests/test_workflow.py

<ul><li>Adds regression test for MultiDataTile ignore_errors with <br>StructuredError<br> <li> Mocks multifile_mode_process to raise StructuredError<br> <li> Asserts error_info and failure status correctness</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/283/files#diff-24e2d1e2ad448ca27676c50d54e09656ecf6f90781d9dad74b9dde4c195b8882">+76/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

