### PR TITLE
Ensure MultiDataTile empty inputs still trigger dataset validation

### DIFF
--- a/src/rdetoolkit/impl/input_controller.py
+++ b/src/rdetoolkit/impl/input_controller.py
@@ -289,6 +289,9 @@ class MultiFileChecker(IInputFileChecker):
         cleaner = SystemFilesCleaner()
         input_files = [f for f in input_files if not cleaner.is_excluded(f)]
         other_files = self._get_group_by_files(input_files)
+        if not other_files:
+            # Align with InvoiceChecker: ensure pipeline executes once even when inputdata is empty
+            return [()], None
         _rawfiles: list[tuple[Path, ...]] = [(f,) for f in other_files]
         return sorted(_rawfiles, key=lambda path: str(path)), None
 

--- a/tests/impl/test_multifile_checker.py
+++ b/tests/impl/test_multifile_checker.py
@@ -1,0 +1,90 @@
+"""Regression tests for :func:`MultiFileChecker.parse`.
+
+Equivalence Partitioning Table
+| API                        | Input/State Partition                  | Rationale                                      | Expected Outcome                         | Test ID     |
+| -------------------------- | -------------------------------------- | ---------------------------------------------- | ---------------------------------------- | ----------- |
+| `MultiFileChecker.parse`   | Only Excel-invoice helper files exist  | No user payloads should still produce a tile   | Returns `[()]`; skips Excel invoice file | `TC-EP-001` |
+| `MultiFileChecker.parse`   | Multiple user payload files exist      | Normal multi-file ingestion case               | Emits one tuple per user file            | `TC-EP-002` |
+
+Boundary Value Table
+| API                        | Boundary             | Rationale                              | Expected Outcome                         | Test ID     |
+| -------------------------- | -------------------- | -------------------------------------- | ---------------------------------------- | ----------- |
+| `MultiFileChecker.parse`   | `min = 0` files      | Absolute lower bound for input payload | Returns `[()]`; no user files detected   | `TC-BV-001` |
+| `MultiFileChecker.parse`   | `min+1 = 1` file     | Smallest valid user payload count      | Returns exactly one tuple with that file | `TC-BV-002` |
+
+Test Execution Commands
+- Direct: `pytest tests/impl/test_multifile_checker.py -q --maxfail=1 --cov=rdetoolkit --cov-branch --cov-report=term-missing --cov-report=html`
+- Via tox: `tox -e py311-module -- tests/impl/test_multifile_checker.py -q --maxfail=1 --cov=rdetoolkit --cov-branch --cov-report=term-missing --cov-report=html`
+"""
+
+from pathlib import Path
+
+import pytest
+
+from rdetoolkit.impl.input_controller import MultiFileChecker
+
+
+@pytest.fixture(name="checker_paths")
+def fixture_checker_paths(tmp_path: Path) -> tuple[MultiFileChecker, Path]:
+    """Provide a checker and a fresh input directory rooted at tmp_path."""
+    input_dir = tmp_path / "inputdata"
+    input_dir.mkdir()
+    checker = MultiFileChecker(tmp_path / "temp")
+    return checker, input_dir
+
+
+def test_multifile_checker_filters_excel_invoice_and_returns_placeholder__tc_ep_001(checker_paths: tuple[MultiFileChecker, Path]) -> None:
+    checker, input_dir = checker_paths
+    excel_invoice_file = input_dir / "dataset_excel_invoice.xlsx"
+    # Given: inputdata with only Excel-invoice metadata
+    excel_invoice_file.touch()
+
+    # When: parsing the directory
+    rawfiles, special_file = checker.parse(input_dir)
+
+    # Then: treated as zero payloads to force validation path
+    assert rawfiles == [()]
+    assert special_file is None
+
+
+def test_multifile_checker_emits_single_tuple_per_payload__tc_ep_002(checker_paths: tuple[MultiFileChecker, Path]) -> None:
+    checker, input_dir = checker_paths
+    first = input_dir / "b_sample.txt"
+    second = input_dir / "a_sample.txt"
+    # Given: two payload files out of order
+    first.touch()
+    second.touch()
+
+    # When: parsing the directory
+    rawfiles, special_file = checker.parse(input_dir)
+
+    # Then: file order is normalized and each tuple contains a single file
+    assert rawfiles == [(second,), (first,)]
+    assert special_file is None
+
+
+def test_multifile_checker_empty_directory_returns_placeholder__tc_bv_001(checker_paths: tuple[MultiFileChecker, Path]) -> None:
+    checker, input_dir = checker_paths
+    # Given: inputdata directory with zero payload files
+    assert list(input_dir.iterdir()) == []
+
+    # When: parsing the directory
+    rawfiles, special_file = checker.parse(input_dir)
+
+    # Then: emits a single empty tuple so downstream validation still runs
+    assert rawfiles == [()]
+    assert special_file is None
+
+
+def test_multifile_checker_single_file_boundary__tc_bv_002(checker_paths: tuple[MultiFileChecker, Path]) -> None:
+    checker, input_dir = checker_paths
+    payload = input_dir / "only_payload.txt"
+    # Given: exactly one payload file
+    payload.touch()
+
+    # When: parsing the directory
+    rawfiles, special_file = checker.parse(input_dir)
+
+    # Then: returns one tuple with that payload
+    assert rawfiles == [(payload,)]
+    assert special_file is None


### PR DESCRIPTION
### **User description**
## Related Issue
- #293

## Changes
- Align `MultiFileChecker.parse` empty-input behavior with Invoice mode so the workflow always executes at least once
- Add regression tests (EP/BV tables, Given/When/Then) covering MultiFileChecker empty/single/multiple payloads

## Out of Scope
- Changes to other processing modes or dataset validators

## Verification
- [x] `pytest tests/impl/test_multifile_checker.py -q`
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix MultiFileChecker to emit placeholder when inputdata is empty
  - Ensures dataset validation runs even with zero files
  - Aligns behavior with InvoiceChecker mode

- Add regression tests for MultiFileChecker empty and multi-file cases
  - Covers equivalence partitioning and boundary values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MultiFileChecker.parse()"] -- "inputdata empty or only Excel-invoice" --> B["Returns [()] (placeholder)"]
  A -- "inputdata has user files" --> C["Returns sorted tuples of files"]
  B -- "Triggers downstream dataset validation" --> D["Validation error if required"]
  C -- "Normal processing" --> E["Ingestion continues"]
  F["New regression tests"] -- "Covers empty/single/multi-file cases" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>input_controller.py</strong><dd><code>Fix MultiFileChecker to emit placeholder tuple on empty input</code></dd></summary>
<hr>

src/rdetoolkit/impl/input_controller.py

<ul><li>Fixes MultiFileChecker to emit [()] when no user files are present<br> <li> Ensures pipeline executes for empty inputdata<br> <li> Aligns behavior with InvoiceChecker</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/295/files#diff-1ba2eed082860db640f1dd55641b7af16fd4566f7f1823cbfb993190871da84c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_multifile_checker.py</strong><dd><code>Add regression tests for MultiFileChecker empty/multi-file cases</code></dd></summary>
<hr>

tests/impl/test_multifile_checker.py

<ul><li>Adds regression tests for MultiFileChecker.parse<br> <li> Covers empty, single, and multiple file scenarios<br> <li> Includes equivalence partitioning and boundary value tests</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/295/files#diff-8e4341a11f439342b49c61cfb24e03a2939931515a4701e83c09876bde11dbed">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

