### PR TITLE
docs: fix broken Magic Variables link in user-guide config documentation

### DIFF
--- a/docs/user-guide/config.en.md
+++ b/docs/user-guide/config.en.md
@@ -256,5 +256,5 @@ thumbnail_name = safe_get_custom_config(
 
 For detailed configuration file specifications:
 
-- [Magic Variables](#magic-variables) - Dynamic metadata replacement functionality (see Magic Variables section above)
+- [Magic Variables](../usage/config/magic_variable.en.md) - Dynamic metadata replacement functionality
 - [API Reference](../api/index.en.md) - Configuration-related API specifications

--- a/docs/user-guide/config.ja.md
+++ b/docs/user-guide/config.ja.md
@@ -256,5 +256,5 @@ thumbnail_name = safe_get_custom_config(
 
 設定ファイルの詳細な仕様については：
 
-- [Magic Variables](#magic-variable機能) - 動的メタデータ置換機能の詳細
+- [Magic Variables](../usage/config/magic_variable.ja.md) - 動的メタデータ置換機能の詳細
 - [API リファレンス](../api/index.ja.md) - 設定関連のAPI仕様


### PR DESCRIPTION
### **User description**
## Related Issue

- Closes #233

## Changes

### Problem

The "Related Information" section in the user-guide configuration documents contained broken links to Magic Variables documentation:

- **Japanese (`docs/user-guide/config.ja.md`)**: Link `[Magic Variables](#magic-variable機能)` pointed to a non-existent anchor within the same document
- **English (`docs/user-guide/config.en.md`)**: Link `[Magic Variables](#magic-variables)` pointed to a non-existent anchor within the same document

### Root Cause

The Magic Variables documentation was originally part of the configuration document but was later extracted into a separate file (`docs/usage/config/magic_variable.*.md`). The internal anchor links were not updated to reflect this structural change.

### Solution

Updated the broken anchor links to point to the correct external Magic Variables documentation files:

| File | Before | After |
|------|--------|-------|
| `docs/user-guide/config.ja.md` | `[Magic Variables](#magic-variable機能)` | `[Magic Variables](../usage/config/magic_variable.ja.md)` |
| `docs/user-guide/config.en.md` | `[Magic Variables](#magic-variables)` | `[Magic Variables](../usage/config/magic_variable.en.md)` |

## Out of Scope

- No changes to the Magic Variables documentation itself
- No changes to navigation structure in `mkdocs.yml`
- No changes to other documentation files that may reference these pages

## Verification

- [x] Link targets exist
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Documentation


___

### **Description**
- Fixed broken Magic Variables links in user-guide config docs

- Updated English and Japanese docs to point to correct files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["user-guide config.en.md"] -- "update Magic Variables link" --> B["usage/config/magic_variable.en.md"]
  C["user-guide config.ja.md"] -- "update Magic Variables link" --> D["usage/config/magic_variable.ja.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.en.md</strong><dd><code>Fix Magic Variables link to external documentation (EN)</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/user-guide/config.en.md

<ul><li>Updated Magic Variables link to point to external documentation<br> <li> Removed broken internal anchor reference</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/354/files#diff-fe71000ada8454e0c9becfeb7c704b5255329193b71d8afa978206aa90da222e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.ja.md</strong><dd><code>Fix Magic Variables link to external documentation (JA)</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/user-guide/config.ja.md

<ul><li>Updated Magic Variables link to point to external documentation<br> <li> Removed broken internal anchor reference</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/354/files#diff-8027356cb248c150df0d799745c38aba6d15f560ec8d673abf837537a0f711c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

