### PR TITLE
Fix badge URLs to nims-mdpf organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![GitHub Release](https://img.shields.io/github/v/release/nims-dpfc/rdetoolkit)
+![GitHub Release](https://img.shields.io/github/v/release/nims-mdpf/rdetoolkit)
 [![python.org](https://img.shields.io/badge/Python-3.9%7C3.10%7C3.11%7C3.12%7C3.13%7C3.14-%233776AB?logo=python)](https://www.python.org/downloads/release/python-3917/)
-[![MIT License](https://img.shields.io/badge/license-MIT-green)](https://github.com/nims-dpfc/rdetoolkit/blob/main/LICENSE)
-[![Issue](https://img.shields.io/badge/issue_tracking-github-orange)](https://github.com/nims-dpfc/rdetoolkit/issues)
-![workflow](https://github.com/nims-dpfc/rdetoolkit/actions/workflows/main.yml/badge.svg)
+[![MIT License](https://img.shields.io/badge/license-MIT-green)](https://github.com/nims-mdpf/rdetoolkit/blob/main/LICENSE)
+[![Issue](https://img.shields.io/badge/issue_tracking-github-orange)](https://github.com/nims-mdpf/rdetoolkit/issues)
+![workflow](https://github.com/nims-mdpf/rdetoolkit/actions/workflows/main.yml/badge.svg)
 ![coverage](docs/img/coverage.svg)
 
 > [日本語ドキュメント](docs/README_ja.md)


### PR DESCRIPTION
### **User description**
## Related Issue
- #358 (badge URLs still pointing to `nims-dpfc`)

## Changes
- Update README badges (release, license, issue tracking, workflow) to use the `nims-mdpf/rdetoolkit` repository URLs.
- Verify remaining documentation badges already reference `nims-mdpf`.

## Out of Scope
- No code or dependency changes.
- No additional documentation restructuring beyond badge URL fixes.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Documentation


___

### **Description**
- Updated all badge URLs in `README.md` to use `nims-mdpf` organization

- Ensured badge links and images point to the correct repository

- No code or dependency changes included


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldBadges["Badge URLs reference nims-dpfc"]
  updateBadges["Update badge URLs to nims-mdpf"]
  correctLinks["Badges link to correct repository"]

  oldBadges -- "edit URLs" --> updateBadges
  updateBadges -- "verify links" --> correctLinks
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update badge URLs to use nims-mdpf organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Changed all badge URLs from <code>nims-dpfc</code> to <code>nims-mdpf</code><br> <li> Updated release, license, issue tracking, and workflow badge links<br> <li> Ensured badges display and link to the correct repository</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/376/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

