### PR TITLE
Fix documentation example typo for `display_message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,20 @@ def dataset(paths: RdeDatasetPaths) -> None:
     ...
 ```
 
-In this example, we define a dummy function `display_messsage()` under `modules` to demonstrate how to implement custom structuring processing. Create a file named `modules/modules.py` as follows:
+In this example, we define a dummy function `display_message()` under `modules` to demonstrate how to implement custom structuring processing. Create a file named `modules/modules.py` as follows:
 
 ```python
 # modules/modules.py
 from rdetoolkit.models.rde2types import RdeDatasetPaths
 
 
-def display_messsage(path):
+def display_message(path):
     print(f"Test Message!: {path}")
 
 
 def dataset(paths: RdeDatasetPaths) -> None:
-    display_messsage(paths.inputdata)
-    display_messsage(paths.struct)
+    display_message(paths.inputdata)
+    display_message(paths.struct)
 ```
 
 ### About the Entry Point

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -87,20 +87,20 @@ def dataset(paths: RdeDatasetPaths) -> None:
     ...
 ```
 
-今回の例では、`modules` 以下に `display_messsage()` というダミー処理を定義し、独自の構造化処理を実装します。`modules/modules.py` というファイルを作成します。
+今回の例では、`modules` 以下に `display_message()` というダミー処理を定義し、独自の構造化処理を実装します。`modules/modules.py` というファイルを作成します。
 
 ```python
 # modules/modules.py
 from rdetoolkit.models.rde2types import RdeDatasetPaths
 
 
-def display_messsage(path):
+def display_message(path):
     print(f"Test Message!: {path}")
 
 
 def dataset(paths: RdeDatasetPaths) -> None:
-    display_messsage(paths.inputdata)
-    display_messsage(paths.struct)
+    display_message(paths.inputdata)
+    display_message(paths.struct)
 ```
 
 ### 起動処理について


### PR DESCRIPTION
### **User description**
## Related Issue
- #359

## Changes
- Rename the example function from `display_messsage` to `display_message` in README and Japanese docs.
- Update corresponding example invocations to use the corrected name.
- Confirm no remaining occurrences of the typo in the repository.

## Out of Scope
- No code logic changes; documentation updates only.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Documentation


___

### **Description**
- Corrected typo in function name from `display_messsage` to `display_message`

- Updated all example code and references in English and Japanese documentation

- Ensured consistency of function naming in documentation examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  typoOld["Function name 'display_messsage' in docs"]
  typoNew["Function name 'display_message' in docs"]
  typoOld -- "rename everywhere" --> typoNew
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix function name typo in English documentation examples</code>&nbsp; </dd></summary>
<hr>

README.md

<ul><li>Renamed all instances of <code>display_messsage</code> to <code>display_message</code><br> <li> Updated example code and explanatory text for accuracy</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/377/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README_ja.md</strong><dd><code>Fix function name typo in Japanese documentation examples</code></dd></summary>
<hr>

docs/README_ja.md

<ul><li>Corrected function name from <code>display_messsage</code> to <code>display_message</code><br> <li> Updated Japanese documentation examples and descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/377/files#diff-43de4122a4a81b8e5a44e83c18887a33a680413d395e21ddaaf2fc3b3ece864c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

