### PR TITLE
Align workflow mode docs and add selection safeguards

### DIFF
--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -423,7 +423,7 @@ def run(*, custom_dataset_function: DatasetCallback | None = None, config: Confi
 
         1. SmartTable CSV is present (`smarttable_file` is not None) -> `SmartTableInvoice` mode.
         2. Excel invoice bundle is provided (`excel_invoice_files` is not None) -> `Excelinvoice` mode.
-        3. `extended_mode` equals `rdeformat` or `MultiDataTile` (exact match) -> the corresponding extended mode.
+        3. `extended_mode` matches (case-insensitive) `rdeformat` or `MultiDataTile` -> the corresponding extended mode.
         4. Otherwise -> `Invoice` mode.
 
         The mode name recorded in logs/results matches the branch that executed. No `excelinvoice` value is accepted in `extended_mode`.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,28 +15,26 @@ from rdetoolkit.models.config import Config, SystemSettings, MultiDataTileSettin
 from rdetoolkit.models.rde2types import RdeInputDirPaths, RdeOutputResourcePath
 from rdetoolkit.models.result import WorkflowExecutionStatus
 
-"""
-| Equivalence Partitioning |
-| API                 | Input/State Partition                              | Rationale                                  | Expected Outcome                                        | Test ID      |
-| ------------------- | -------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------- | ------------ |
-| _process_mode       | smarttable file present                            | SmartTable branch has highest precedence   | SmartTableInvoice mode executes                         | TC-EP-001    |
-| _process_mode       | excel invoice present, extended_mode also set      | Excelinvoice should precede extended_mode  | Excelinvoice mode executes                              | TC-EP-002    |
-| _process_mode       | extended_mode="rdeformat"                          | Valid extended_mode value                  | rdeformat mode executes                                 | TC-EP-003    |
-| _process_mode       | extended_mode=\"MultiDataTile\", ignore_errors=False | Multidata tile failure should bubble       | StructuredError is raised                               | TC-EP-004    |
-| _process_mode       | downstream handler returns None                    | Guard against missing status               | StructuredError is raised                               | TC-EP-005    |
-| _process_mode       | downstream handler returns status.failed           | Failures must raise StructuredError        | StructuredError with error_code propagates              | TC-EP-006    |
-| _process_mode       | downstream handler raises generic Exception        | Unexpected errors are wrapped              | StructuredError is raised with wrapped message          | TC-EP-007    |
-
-| Boundary Value |
-| API           | Boundary Scenario                                        | Rationale                                        | Expected Outcome                         | Test ID      |
-| ------------- | -------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------- | ------------ |
-| _process_mode | smarttable vs excel inputs present                       | Confirms first-branch priority boundary          | SmartTableInvoice chosen (not Excelinvoice) | TC-EP-001    |
-| _process_mode | excel present while extended_mode also configured        | Confirms second/third priority boundary          | Excelinvoice chosen (not extended_mode)  | TC-EP-002    |
-| _process_mode | extended_mode set to allowed value                    | Boundary between valid extended_mode and default | rdeformat branch executes                | TC-EP-003    |
-| _process_mode | MultiDataTile ignore_errors=False                        | Boundary between handled/unhandled exceptions    | StructuredError raised                   | TC-EP-004    |
-| _process_mode | handler returns None vs valid WorkflowExecutionStatus    | Boundary between valid/invalid status responses  | StructuredError raised on None           | TC-EP-005    |
-| _process_mode | handler returns status.failed                            | Boundary between success and explicit failure    | StructuredError raised                   | TC-EP-006    |
-"""
+# Equivalence Partitioning Table
+# | API           | Input/State Partition                              | Rationale                                  | Expected Outcome                             | Test ID   |
+# | ------------- | -------------------------------------------------- | ------------------------------------------ | -------------------------------------------- | --------- |
+# | _process_mode | smarttable file present                            | SmartTable branch has highest precedence   | SmartTableInvoice mode executes              | TC-EP-001 |
+# | _process_mode | excel invoice present, extended_mode also set      | Excelinvoice should precede extended_mode  | Excelinvoice mode executes                   | TC-EP-002 |
+# | _process_mode | extended_mode="rdeformat"                          | Valid extended_mode value                  | rdeformat mode executes                      | TC-EP-003 |
+# | _process_mode | extended_mode="MultiDataTile", ignore_errors=False | Multidata tile failure should bubble       | StructuredError is raised                    | TC-EP-004 |
+# | _process_mode | downstream handler returns None                    | Guard against missing status               | StructuredError is raised                    | TC-EP-005 |
+# | _process_mode | downstream handler returns status.failed           | Failures must raise StructuredError        | StructuredError with error_code propagates   | TC-EP-006 |
+# | _process_mode | downstream handler raises generic Exception        | Unexpected errors are wrapped              | StructuredError is raised with wrapped msg   | TC-EP-007 |
+#
+# Boundary Value Table
+# | API           | Boundary Scenario                                     | Rationale                                        | Expected Outcome                            | Test ID   |
+# | ------------- | ----------------------------------------------------- | ------------------------------------------------ | ------------------------------------------- | --------- |
+# | _process_mode | smarttable vs excel inputs present                    | Confirms first-branch priority boundary          | SmartTableInvoice chosen (not Excelinvoice) | TC-EP-001 |
+# | _process_mode | excel present while extended_mode also configured     | Confirms second/third priority boundary          | Excelinvoice chosen (not extended_mode)     | TC-EP-002 |
+# | _process_mode | extended_mode set to allowed value                    | Boundary between valid extended_mode and default | rdeformat branch executes                   | TC-EP-003 |
+# | _process_mode | MultiDataTile ignore_errors=False                     | Boundary between handled/unhandled exceptions    | StructuredError raised                      | TC-EP-004 |
+# | _process_mode | handler returns None vs valid WorkflowExecutionStatus | Boundary between valid/invalid status responses  | StructuredError raised on None              | TC-EP-005 |
+# | _process_mode | handler returns status.failed                         | Boundary between success and explicit failure    | StructuredError raised                      | TC-EP-006 |
 
 
 @pytest.fixture
@@ -792,13 +790,13 @@ def test_process_mode_uses_extended_mode_value__tc_ep_003(tmp_path, monkeypatch)
     )
 
     # Then
-    assert called, "rdeformat branch should execute when extended_mode equals rdeformat (case-insensitive)"
+    assert called, "rdeformat branch should execute when extended_mode equals 'rdeformat'"
     assert mode == "rdeformat"
     assert status.status == "success"
     assert error_info is None
 
 
-def test_process_mode_multidatatitle_propagates_structured_error__tc_ep_004(tmp_path, monkeypatch):
+def test_process_mode_multidatatile_propagates_structured_error__tc_ep_004(tmp_path, monkeypatch):
     """Given MultiDataTile without ignore_errors, when handler raises StructuredError, then it propagates."""
     srcpaths, rdeoutput_resource, config = _make_paths(tmp_path, extended_mode="MultiDataTile", ignore_errors=False)
 


### PR DESCRIPTION
### **User description**
## Related Issue
- #370

## Changes
- Update `workflows.run` note to document the real mode precedence and allowed `extended_mode` values.
- Add EP/BV tables and new `_process_mode` unit tests covering priority order and failure handling (structured errors, missing status, failed status, unexpected exceptions).
- Document test command used for the new cases.

## Out of Scope
- No runtime behavior changes beyond documentation and tests; config validation rules remain unchanged.

## Verification
- [x] `pytest tests/test_workflow.py -k process_mode --maxfail=1`
- [ ] No issues with the modified scripts


___

### **PR Type**
Documentation, Tests


___

### **Description**
- Clarified `workflows.run` docstring to match actual mode selection logic.

- Added comprehensive unit tests for `_process_mode` covering mode precedence and error handling.

- Included equivalence partitioning and boundary value tables as test documentation.

- Improved test naming and assertion clarity for mode selection.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  docstring["Update run() docstring"]
  tests["Add _process_mode unit tests"]
  tables["Add EP/BV tables as comments"]
  docstring -- "Clarifies mode selection logic" --> tests
  tests -- "Covers all mode precedence and errors" --> tables
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workflows.py</strong><dd><code>Clarify run() docstring to match actual mode selection</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/workflows.py

<ul><li>Updated the <code>run</code> function docstring to accurately describe mode <br>selection order.<br> <li> Clarified that <code>excelinvoice</code> is not a valid <code>extended_mode</code> value.<br> <li> Improved documentation for user and developer clarity.</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/378/files#diff-b2128aab32afd5b3f02c8b34e80d2310c175aee4134bfb3fb2d0dba0015f345e">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_workflow.py</strong><dd><code>Add comprehensive _process_mode mode selection and error tests</code></dd></summary>
<hr>

tests/test_workflow.py

<ul><li>Added detailed unit tests for <code>_process_mode</code> covering all mode <br>selection branches and error cases.<br> <li> Included equivalence partitioning and boundary value tables as <br>comments.<br> <li> Improved test naming and assertion messages for clarity.<br> <li> Ensured coverage for SmartTable, Excelinvoice, extended_mode, and <br>error propagation.</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/378/files#diff-24e2d1e2ad448ca27676c50d54e09656ecf6f90781d9dad74b9dde4c195b8882">+301/-17</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

