### PR TITLE
fix: Remove stale TODO and fix docstring typo in invoicefile.py

### DIFF
--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -160,7 +160,7 @@ def check_exist_rawfiles(dfexcelinvoice: pd.DataFrame, excel_rawfiles: list[Path
         excel_rawfiles (list[Path]): A list of Path objects representing file paths.
 
     Raises:
-        tructuredError: If any file name in dfexcelinvoice is not found in excel_rawfiles.
+        StructuredError: If any file name in dfexcelinvoice is not found in excel_rawfiles.
 
     Returns:
         list[Path]: A list of Path objects corresponding to the file names in dfexcelinvoice, ordered as they appear in the DataFrame.
@@ -1152,7 +1152,8 @@ class RuleBasedReplacer:
         Args:
             replacements (Mapping[str, Any]): The object containing mapping rules (read-only).
             source_json_obj (MutableMapping[str, Any] | None): Objects of key and value to which you want to apply the rule (performs nested assignments).
-            mapping_rules (Mapping[str, str] | None, optional): Rules for mapping key and value (read-only). Defaults to None.
+            mapping_rules (Mapping[str, str] | None, optional): Rules for mapping key and value (read-only).
+                If None, uses self.rules. Defaults to None.
 
         Returns:
             dict[str, Any]: dictionary type data after conversion
@@ -1173,13 +1174,12 @@ class RuleBasedReplacer:
             result = replacer.apply_rules(replacement_rule, save_file_path, mapping_rules = rule)
             print(result)
         """
-        # [TODO] Correction of type definitions in version 0.1.6
         if mapping_rules is None:
             mapping_rules = self.rules
         if source_json_obj is None:
             source_json_obj = {}
 
-        for key, value in self.rules.items():
+        for key, value in mapping_rules.items():
             keys = key.split(".")
             replace_value = replacements.get(value, "")
             current_obj: MutableMapping[str, Any] = source_json_obj


### PR DESCRIPTION
### **User description**
## Related Issue
- #399

## Changes
- Remove obsolete TODO comment from line 1177 (`# [TODO] Correction of type definitions in version 0.1.6`)
- Fix bug in `get_apply_rules_obj` method where `mapping_rules` parameter was ignored (was using `self.rules` instead)
- Improve docstring for `mapping_rules` parameter to clarify default behavior
- Fix typo in `check_exist_rawfiles` docstring: `tructuredError` → `StructuredError`

## Out of Scope
- Migration of other type hints in the module
- Additional mypy strictness configuration

## Verification
- [x] CI tests pass successfully (55 tests passed)
- [x] No issues with the modified scripts
- [x] ruff linting passed
- [x] mypy type checking passed


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed docstring typo: corrected `tructuredError` to `StructuredError`

- Removed obsolete TODO comment about type definitions

- Fixed bug in `get_apply_rules_obj`: now uses `mapping_rules` parameter correctly

- Improved docstring for `mapping_rules` to clarify default behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Obsolete TODO in get_apply_rules_obj"] -- "Removed" --> B["Cleaner code"]
  C["Docstring typo: tructuredError"] -- "Fixed to StructuredError" --> D["Accurate documentation"]
  E["get_apply_rules_obj uses self.rules"] -- "Now uses mapping_rules param" --> F["Correct rule application"]
  G["mapping_rules docstring unclear"] -- "Clarified default behavior" --> H["Improved documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invoicefile.py</strong><dd><code>Docstring fixes, TODO removal, and mapping_rules logic correction</code></dd></summary>
<hr>

src/rdetoolkit/invoicefile.py

<ul><li>Fixed docstring typo in <code>check_exist_rawfiles</code> (StructuredError)<br> <li> Removed outdated TODO comment in <code>get_apply_rules_obj</code><br> <li> Corrected logic to use <code>mapping_rules</code> parameter instead of <code>self.rules</code><br> <li> Enhanced docstring for <code>mapping_rules</code> to clarify default usage</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/401/files#diff-416b6ece1abaceb864fcfcb5906af70fcfafd42b9393e331cac7e4cb0cf60668">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

