### PR TITLE
fix: Set sample.ownerId to basic.dataOwnerId in SmartTable processing

### DIFF
--- a/src/rdetoolkit/processing/processors/invoice.py
+++ b/src/rdetoolkit/processing/processors/invoice.py
@@ -411,6 +411,7 @@ class SmartTableInvoiceInitializer(Processor):
         """Apply SmartTable row data to invoice and collect metadata updates."""
         metadata_updates: dict[str, dict[str, Any]] = {}
         metadata_def: dict[str, Any] | None = None
+        csv_has_sample_owner_id = False
 
         # Handle empty CSV (no data rows)
         if len(csv_data) == 0:
@@ -435,10 +436,14 @@ class SmartTableInvoiceInitializer(Processor):
                 meta_key, meta_entry = self._process_meta_mapping(col, value, metadata_def)
                 metadata_updates[meta_key] = meta_entry
                 continue
+            # Track if sample/ownerId is explicitly specified in CSV
+            if col == "sample/ownerId":
+                csv_has_sample_owner_id = True
             self._process_mapping_key(col, value, invoice_data, invoice_schema_json_data)
 
-        # Set sample.ownerId to basic.dataOwnerId for SmartTable processing
-        self._set_sample_owner_id(invoice_data)
+        # Set sample.ownerId to basic.dataOwnerId only if not specified in CSV
+        if not csv_has_sample_owner_id:
+            self._set_sample_owner_id(invoice_data)
 
         return metadata_updates
 


### PR DESCRIPTION
## Related Issue

Fixes #389

## Changes

### Problem
In SmartTable mode, when registering samples, `sample.ownerId` was not being updated to reflect the data owner. Instead, it retained the sample owner ID from the temporary sample selected in the invoice screen. This caused:
1. The sample owner to be different from the data registrant for new sample registration
2. Registration errors when the sample owner was not a member of the research team

### Solution
Added automatic `sample.ownerId` assignment in `SmartTableInvoiceInitializer._apply_smarttable_row` with the following priority rules:

| Case | Behavior |
|------|----------|
| SmartTable CSV specifies `sample/ownerId` | Use CSV value (respect user intent) |
| SmartTable CSV does not specify `sample/ownerId` | Use `basic.dataOwnerId` |
| `basic.dataOwnerId` is missing/empty | Log warning, preserve original value |

**Implementation details**:

1. **New helper method `_set_sample_owner_id`**:
   - Sets `sample.ownerId` to `basic.dataOwnerId` after SmartTable row processing
   - Logs a warning if `basic.dataOwnerId` is missing or empty (preserves existing value)

2. **CSV precedence tracking**:
   - Added `csv_has_sample_owner_id` flag to detect explicit CSV specification
   - Only applies `basic.dataOwnerId` when CSV does not specify `sample/ownerId`

3. **Comprehensive test coverage**:
   - Updated existing tests (TC-EP-001, TC-BV-001) with new expected values
   - Added edge case tests (TC-EP-003, TC-BV-003) for missing/empty dataOwnerId
   - Added precedence test (TC-EP-004) to verify CSV value takes precedence when specified

### Files Changed
- `src/rdetoolkit/processing/processors/invoice.py`: Added `_set_sample_owner_id` method and CSV tracking
- `tests/test_smarttable_invoice_initializer.py`: Updated and added test cases (7 total)

## Out of Scope

- Changes to link registration behavior (sample.ownerId is not used for linking, but is set as a safe default)
- Modifications to the invoice schema or CSV format

## Verification

- [x] CI tests pass successfully
- [x] No issues with the modified scripts
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [x] All 7 SmartTable invoice initializer tests pass
- [x] All 44 invoice-related tests pass