### PR TITLE
#420 Fix Agent Skills directory structure for multi-agent support

### DIFF
--- a/docs/usage/agent_skills.en.md
+++ b/docs/usage/agent_skills.en.md
@@ -46,27 +46,80 @@ cd rdetoolkit
 
 ### Adding to your own project
 
-If you're developing a structured processing project in a separate repository, copy the `.agents/` directory into your project.
+If you're developing a structured processing project in a separate repository, follow these steps.
+
+#### 1. Copy the canonical source
+
+Place the skill files in `.agents/skills/rdetoolkit-skill/`.
 
 ```bash
-# Copy .agents/ from rdetoolkit into your project
-cp -r /path/to/rdetoolkit/src/rdetoolkit/.agents/ ./your-project/.agents/
+# Copy skill files from rdetoolkit repository
+mkdir -p ./your-project/.agents/skills/rdetoolkit-skill
+cp -r /path/to/rdetoolkit/src/rdetoolkit/.agents/* ./your-project/.agents/skills/rdetoolkit-skill/
 ```
 
-Claude Code auto-detects the skills when `.agents/SKILL.md` exists at the project root or under a src directory.
+#### 2. Create symlinks for your AI agent(s)
+
+Each AI coding assistant reads skill files from its own dedicated directory. Create symlinks (or copies) for the agents you use.
+
+```bash
+# For Claude Code
+mkdir -p .claude/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .claude/skills/rdetoolkit-skill
+
+# For GitHub Copilot
+mkdir -p .github/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .github/skills/rdetoolkit-skill
+
+# For Gemini CLI
+mkdir -p .gemini/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .gemini/skills/rdetoolkit-skill
+
+# For OpenCode
+mkdir -p .opencode/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .opencode/skills/rdetoolkit-skill
+
+# For Devin
+mkdir -p .devin/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .devin/skills/rdetoolkit-skill
+```
+
+You only need to set up the directories for the agents you actually use.
 
 ## Agent Skills structure
 
+When added to your own project, the directory layout looks like this:
+
 ```
-.agents/
-├── SKILL.md                    # Entry point
-└── references/
-    ├── building-structured-processing.md  # Structured processing build pattern
-    ├── preferred-apis.md                  # fileops & csv2graph API
-    ├── cli-workflow.md                    # CLI execution order guide
-    ├── config.md                          # Configuration file spec
-    └── modes.md                           # Processing mode details
+your-project/
+├── .agents/
+│   └── skills/
+│       └── rdetoolkit-skill/           # ← Canonical source (actual files)
+│           ├── SKILL.md                #    Entry point
+│           └── references/
+│               ├── building-structured-processing.md
+│               ├── preferred-apis.md
+│               ├── cli-workflow.md
+│               ├── config.md
+│               └── modes.md
+├── .claude/
+│   └── skills/
+│       └── rdetoolkit-skill/           # For Claude Code (symlink)
+├── .github/
+│   └── skills/
+│       └── rdetoolkit-skill/           # For GitHub Copilot (symlink)
+├── .gemini/
+│   └── skills/
+│       └── rdetoolkit-skill/           # For Gemini CLI (symlink)
+├── .opencode/
+│   └── skills/
+│       └── rdetoolkit-skill/           # For OpenCode (symlink)
+└── .devin/
+    └── skills/
+        └── rdetoolkit-skill/           # For Devin (symlink)
 ```
+
+`.agents/skills/rdetoolkit-skill/` is the single source of truth. Agent-specific directories contain symlinks pointing back to it. Updating the canonical source automatically propagates changes to all agents.
 
 ### SKILL.md
 

--- a/docs/usage/agent_skills.ja.md
+++ b/docs/usage/agent_skills.ja.md
@@ -46,27 +46,80 @@ cd rdetoolkit
 
 ### 自分のプロジェクトに導入する
 
-rdetoolkitを使った構造化処理プロジェクトを独立リポジトリで開発している場合は、`.agents/`ディレクトリをコピーして配置してください。
+rdetoolkitを使った構造化処理プロジェクトを独立リポジトリで開発している場合は、以下の手順で配置してください。
+
+#### 1. 正典ソースをコピーする
+
+`.agents/skills/rdetoolkit-skill/` に実体を配置します。
 
 ```bash
-# rdetoolkitリポジトリの.agents/を自分のプロジェクトにコピー
-cp -r /path/to/rdetoolkit/src/rdetoolkit/.agents/ ./your-project/.agents/
+# rdetoolkitリポジトリからスキルファイルをコピー
+mkdir -p ./your-project/.agents/skills/rdetoolkit-skill
+cp -r /path/to/rdetoolkit/src/rdetoolkit/.agents/* ./your-project/.agents/skills/rdetoolkit-skill/
 ```
 
-プロジェクト直下またはsrcディレクトリ直下に`.agents/SKILL.md`が存在すれば、Claude Codeは自動検出します。
+#### 2. 使用するAIエージェント用にシンボリックリンクを作成する
+
+各AIコーディングアシスタントはそれぞれ専用のディレクトリからスキルファイルを読み込みます。使用するエージェントに合わせてシンボリックリンク（またはコピー）を作成してください。
+
+```bash
+# Claude Code 用
+mkdir -p .claude/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .claude/skills/rdetoolkit-skill
+
+# GitHub Copilot 用
+mkdir -p .github/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .github/skills/rdetoolkit-skill
+
+# Gemini CLI 用
+mkdir -p .gemini/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .gemini/skills/rdetoolkit-skill
+
+# OpenCode 用
+mkdir -p .opencode/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .opencode/skills/rdetoolkit-skill
+
+# Devin 用
+mkdir -p .devin/skills
+ln -s ../../.agents/skills/rdetoolkit-skill .devin/skills/rdetoolkit-skill
+```
+
+すべてのエージェントに対応する必要はありません。使用するツールに対応するディレクトリだけ作成すれば十分です。
 
 ## Agent Skillsの構成
 
+自分のプロジェクトに導入した場合のディレクトリ構成は以下のようになります。
+
 ```
-.agents/
-├── SKILL.md                    # エントリポイント
-└── references/
-    ├── building-structured-processing.md  # 構造化処理の構築パターン
-    ├── preferred-apis.md                  # fileops・csv2graph API
-    ├── cli-workflow.md                    # CLI実行順序ガイド
-    ├── config.md                          # 設定ファイル仕様
-    └── modes.md                           # 処理モード詳細
+your-project/
+├── .agents/
+│   └── skills/
+│       └── rdetoolkit-skill/           # ← 実体（正典ソース）
+│           ├── SKILL.md                #    エントリポイント
+│           └── references/
+│               ├── building-structured-processing.md
+│               ├── preferred-apis.md
+│               ├── cli-workflow.md
+│               ├── config.md
+│               └── modes.md
+├── .claude/
+│   └── skills/
+│       └── rdetoolkit-skill/           # Claude Code 用（シンボリックリンク）
+├── .github/
+│   └── skills/
+│       └── rdetoolkit-skill/           # GitHub Copilot 用（シンボリックリンク）
+├── .gemini/
+│   └── skills/
+│       └── rdetoolkit-skill/           # Gemini CLI 用（シンボリックリンク）
+├── .opencode/
+│   └── skills/
+│       └── rdetoolkit-skill/           # OpenCode 用（シンボリックリンク）
+└── .devin/
+    └── skills/
+        └── rdetoolkit-skill/           # Devin 用（シンボリックリンク）
 ```
+
+`.agents/skills/rdetoolkit-skill/` が唯一の実体で、各エージェント用ディレクトリにはシンボリックリンクを配置します。スキルファイルの更新は正典ソースだけで済み、すべてのエージェントに自動で反映されます。
 
 ### SKILL.md
 


### PR DESCRIPTION
## Summary

- Agent Skillsのドキュメントで、自分のプロジェクトへの導入手順を修正
- 各AIエージェント（Claude Code, GitHub Copilot, Gemini CLI, OpenCode, Devin）がそれぞれ固有のディレクトリからスキルを読み取ることを明示
- `.agents/skills/rdetoolkit-skill/` を正典ソースとし、各エージェント用ディレクトリにはシンボリックリンクで配置する手順を追加
- 日本語・英語の両ドキュメントを更新

## Test plan

- [ ] `mkdocs serve` でドキュメントのレンダリングを確認
- [ ] シンボリックリンクのコマンド例が正しいパスを指していることを確認
- [ ] 日英のドキュメント内容が整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)