### PR TITLE
Improve SmartTable missing file errors for zip input references

### DIFF
--- a/src/rdetoolkit/invoicefile/_smarttable.py
+++ b/src/rdetoolkit/invoicefile/_smarttable.py
@@ -131,12 +131,13 @@ class SmartTableFile:
         data = self.read_table()
         csv_file_mappings = []
         missing_references: list[tuple[int, str, str]] = []
+        zip_was_uploaded = extracted_files is not None
 
         pd = _ensure_pandas()
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
             inputdata_columns = [col for col in data.columns if col.startswith("inputdata")]
-            available_files = extracted_files or []
+            available_files = extracted_files if extracted_files is not None else []
 
             for idx, row in data.iterrows():
                 # New naming convention: smarttable_<original_filename>_XXXX.csv
@@ -167,20 +168,10 @@ class SmartTableFile:
                 csv_file_mappings.append((csv_path, tuple(related_files)))
 
             if missing_references:
-                logger.error(
-                    "SmartTable references files missing from the uploaded zip:\n%s",
-                    "\n".join(
-                        f"row {row_number}: {column}={relative_path}"
-                        for row_number, column, relative_path in missing_references
-                    ),
+                self._raise_missing_reference_error(
+                    missing_references,
+                    zip_was_uploaded=zip_was_uploaded,
                 )
-                first_row_number, first_column, first_path = missing_references[0]
-                error_msg = (
-                    "SmartTable row "
-                    f"{first_row_number} references missing file in zip: "
-                    f"{first_column}={self._basename_for_message(first_path)}"
-                )
-                raise StructuredError(error_msg, eobj=missing_references)
             return csv_file_mappings
 
         except StructuredError:
@@ -223,9 +214,63 @@ class SmartTableFile:
         first_data_row_number = 3
         return int(data_row_index) + first_data_row_number
 
+    def _raise_missing_reference_error(
+        self,
+        missing_references: list[tuple[int, str, str]],
+        *,
+        zip_was_uploaded: bool,
+    ) -> None:
+        """Raise a user-facing error for unresolved inputdata references."""
+        logger.error(
+            self._missing_reference_log_message(zip_was_uploaded),
+            self._format_missing_references_for_log(missing_references),
+        )
+        first_row_number, first_column, first_path = missing_references[0]
+        first_column_label = self._sanitize_text(first_column)
+        first_basename = self._basename_for_message(first_path)
+        if zip_was_uploaded:
+            error_msg = (
+                "SmartTable row "
+                f"{first_row_number} references missing file in uploaded zip: "
+                f"{first_column_label}={first_basename}"
+            )
+        else:
+            error_msg = (
+                "SmartTable row "
+                f"{first_row_number} references {first_column_label}={first_basename} "
+                "but no zip was uploaded"
+            )
+        raise StructuredError(error_msg, eobj=missing_references)
+
+    def _missing_reference_log_message(self, zip_was_uploaded: bool) -> str:
+        """Return the summary log message for unresolved inputdata references."""
+        if zip_was_uploaded:
+            return "SmartTable references files missing from the uploaded zip:\n%s"
+        return "SmartTable references inputdata files but no zip was uploaded:\n%s"
+
+    def _format_missing_references_for_log(self, missing_references: list[tuple[int, str, str]]) -> str:
+        """Render missing references as a control-character-safe log payload."""
+        return "\n".join(
+            "row "
+            f"{row_number}: {self._sanitize_text(column)}={self._sanitize_text(relative_path)}"
+            for row_number, column, relative_path in missing_references
+        )
+
     def _basename_for_message(self, relative_path: str) -> str:
         """Return a short filename for user-facing error messages."""
         normalized_path = relative_path.strip().strip("/\\").replace("\\", "/")
         if not normalized_path:
-            return relative_path
-        return Path(normalized_path).name
+            return self._sanitize_text(relative_path)
+        return self._sanitize_text(Path(normalized_path).name)
+
+    def _sanitize_text(self, value: str) -> str:
+        """Escape control characters before including user-provided text in logs/messages."""
+        replacements = {
+            "\n": "\\n",
+            "\r": "\\r",
+            "\t": "\\t",
+        }
+        return "".join(
+            replacements.get(char, char if char.isprintable() else f"\\x{ord(char):02x}")
+            for char in value
+        )

--- a/src/rdetoolkit/invoicefile/_smarttable.py
+++ b/src/rdetoolkit/invoicefile/_smarttable.py
@@ -11,9 +11,12 @@ from typing import TYPE_CHECKING
 
 from rdetoolkit.exceptions import StructuredError
 from rdetoolkit.invoicefile._helpers import _ensure_pandas
+from rdetoolkit.rdelogger import get_logger
 
 if TYPE_CHECKING:
     import pandas as pd
+
+logger = get_logger(__name__)
 
 
 class SmartTableFile:
@@ -127,11 +130,13 @@ class SmartTableFile:
         """
         data = self.read_table()
         csv_file_mappings = []
+        missing_references: list[tuple[int, str, str]] = []
 
         pd = _ensure_pandas()
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
             inputdata_columns = [col for col in data.columns if col.startswith("inputdata")]
+            available_files = extracted_files or []
 
             for idx, row in data.iterrows():
                 # New naming convention: smarttable_<original_filename>_XXXX.csv
@@ -148,17 +153,38 @@ class SmartTableFile:
                     if pd.isna(file_relative_path) or file_relative_path == "":
                         continue
 
-                    # Find matching file in extracted files
-                    if extracted_files:
-                        matching_file = self._find_file_by_relative_path(
-                            file_relative_path, extracted_files,
-                        )
-                        if matching_file:
-                            related_files.append(matching_file)
+                    matching_file = self._find_file_by_relative_path(
+                        str(file_relative_path), available_files,
+                    )
+                    if matching_file:
+                        related_files.append(matching_file)
+                        continue
+
+                    missing_references.append(
+                        (self._to_smarttable_row_number(idx), col, str(file_relative_path)),
+                    )
 
                 csv_file_mappings.append((csv_path, tuple(related_files)))
+
+            if missing_references:
+                logger.error(
+                    "SmartTable references files missing from the uploaded zip:\n%s",
+                    "\n".join(
+                        f"row {row_number}: {column}={relative_path}"
+                        for row_number, column, relative_path in missing_references
+                    ),
+                )
+                first_row_number, first_column, first_path = missing_references[0]
+                error_msg = (
+                    "SmartTable row "
+                    f"{first_row_number} references missing file in zip: "
+                    f"{first_column}={self._basename_for_message(first_path)}"
+                )
+                raise StructuredError(error_msg, eobj=missing_references)
             return csv_file_mappings
 
+        except StructuredError:
+            raise
         except Exception as e:
             error_msg = f"Failed to generate CSV files with file mapping: {str(e)}"
             raise StructuredError(error_msg) from e
@@ -191,3 +217,15 @@ class SmartTableFile:
                 if relative_part == normalized_path.replace("\\", "/"):
                     return file_path
         return None
+
+    def _to_smarttable_row_number(self, data_row_index: int) -> int:
+        """Convert a zero-based data row index to a SmartTable display row number."""
+        first_data_row_number = 3
+        return int(data_row_index) + first_data_row_number
+
+    def _basename_for_message(self, relative_path: str) -> str:
+        """Return a short filename for user-facing error messages."""
+        normalized_path = relative_path.strip().strip("/\\").replace("\\", "/")
+        if not normalized_path:
+            return relative_path
+        return Path(normalized_path).name

--- a/tests/test_smarttable_file.py
+++ b/tests/test_smarttable_file.py
@@ -1,4 +1,17 @@
-"""Test SmartTableFile functionality."""
+"""Test SmartTableFile functionality with SmartTable file-mapping coverage.
+
+Equivalence Partitioning:
+| API | Input/State Partition | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | All `inputdata` values resolve to extracted files | Valid SmartTable references should preserve current behavior | Returns per-row CSV mappings with related files | `TC-EP-001` |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | One `inputdata` value does not exist in extracted files | Missing file should fail early with actionable context | Raises `StructuredError` including row, column, basename | `TC-EP-002` |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | Multiple `inputdata` values are missing across rows | UI needs one concise example while logs keep all details | Raises representative `StructuredError` and logs all mismatches | `TC-EP-003` |
+|
+Boundary Value:
+| API | Boundary | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | Second data row (`idx=1`) in SmartTable | User-facing row number must match the displayed SmartTable row (`4`) | Error message reports SmartTable row `4` | `TC-BV-001` |
+"""
 
 from pathlib import Path
 import pytest
@@ -54,7 +67,7 @@ class TestSmartTableFile:
         test_data = pd.DataFrame({
             'A': ['Display Name 1', 'basic/dataName', 'Sample1', 'Sample2'],
             'B': ['Display Name 2', 'custom/value', 'Value1', 'Value2'],
-            'C': ['Display Name 3', 'sample/name', 'Name1', 'Name2']
+            'C': ['Display Name 3', 'sample/name', 'Name1', 'Name2'],
         })
         test_data.to_excel(excel_file, index=False, header=False)
 
@@ -117,7 +130,8 @@ Sample1,データ1"""
 
 
     def test_generate_row_csvs_with_file_mapping(self, tmp_path):
-        """Test generating individual CSV files for each row with file mapping."""
+        """TC-EP-001: Generating individual CSV files keeps related file mappings."""
+        # Given: a SmartTable whose inputdata values all exist in extracted files
         csv_file = tmp_path / "smarttable_test.csv"
         csv_content = """File,Name,Value
 inputdata1,basic/dataName,custom/value
@@ -131,12 +145,15 @@ test2.txt,Sample2,Value2"""
         extracted_files = [
             Path("/temp/test1.txt"),
             Path("/temp/test2.txt"),
-            Path("/temp/other.txt")
+            Path("/temp/other.txt"),
         ]
 
         st_file = SmartTableFile(csv_file)
+
+        # When: generating row CSV files with extracted file mappings
         result = st_file.generate_row_csvs_with_file_mapping(output_dir, extracted_files)
 
+        # Then: each row CSV is created and linked to the matching extracted file
         assert len(result) == 2
 
         # Check first row - new naming convention
@@ -150,6 +167,83 @@ test2.txt,Sample2,Value2"""
         assert csv_path_1.name == "fsmarttable_test_0001.csv"
         assert csv_path_1.exists()
         assert related_files_1 == (Path("/temp/test2.txt"),)
+
+    def test_generate_row_csvs_with_file_mapping_raises_for_missing_file__tc_ep_002(self, tmp_path, caplog):
+        """TC-EP-002: Missing inputdata file raises a concise StructuredError."""
+        # Given: a SmartTable row that references a file absent from the uploaded zip
+        csv_file = tmp_path / "smarttable_missing.csv"
+        csv_file.write_text(
+            """File,Name
+inputdata1,basic/dataName
+nested/results/missing_file.dat,Sample1""",
+        )
+        output_dir = tmp_path / "output"
+        extracted_files = [Path("/temp/results/present_file.dat")]
+        st_file = SmartTableFile(csv_file)
+        caplog.set_level("ERROR", logger="rdetoolkit.invoicefile._smarttable")
+
+        # When: generating row CSV files with an unresolved inputdata reference
+        with pytest.raises(StructuredError) as exc_info:
+            st_file.generate_row_csvs_with_file_mapping(output_dir, extracted_files)
+
+        # Then: the error exposes SmartTable row, column, and basename only
+        error = exc_info.value
+        assert str(error) == "SmartTable row 3 references missing file in zip: inputdata1=missing_file.dat"
+        assert "nested/results/missing_file.dat" not in str(error)
+        assert error.eobj == [(3, "inputdata1", "nested/results/missing_file.dat")]
+        assert "row 3: inputdata1=nested/results/missing_file.dat" in caplog.text
+
+    def test_generate_row_csvs_with_file_mapping_logs_all_missing_files__tc_ep_003(self, tmp_path, caplog):
+        """TC-EP-003: Multiple missing inputdata files are aggregated in logs."""
+        # Given: multiple SmartTable rows whose inputdata references do not exist in the uploaded zip
+        csv_file = tmp_path / "smarttable_multiple_missing.csv"
+        csv_file.write_text(
+            """File,Second File,Name
+inputdata1,inputdata2,basic/dataName
+missing/first.dat,missing/second.dat,Sample1
+missing/third.dat,,Sample2""",
+        )
+        output_dir = tmp_path / "output"
+        extracted_files = [Path("/temp/present.dat")]
+        st_file = SmartTableFile(csv_file)
+        caplog.set_level("ERROR", logger="rdetoolkit.invoicefile._smarttable")
+
+        # When: generating row CSV files encounters multiple unresolved references
+        with pytest.raises(StructuredError) as exc_info:
+            st_file.generate_row_csvs_with_file_mapping(output_dir, extracted_files)
+
+        # Then: the exception uses the first representative case and the log keeps all mismatches
+        error = exc_info.value
+        assert str(error) == "SmartTable row 3 references missing file in zip: inputdata1=first.dat"
+        assert error.eobj == [
+            (3, "inputdata1", "missing/first.dat"),
+            (3, "inputdata2", "missing/second.dat"),
+            (4, "inputdata1", "missing/third.dat"),
+        ]
+        assert "row 3: inputdata1=missing/first.dat" in caplog.text
+        assert "row 3: inputdata2=missing/second.dat" in caplog.text
+        assert "row 4: inputdata1=missing/third.dat" in caplog.text
+
+    def test_generate_row_csvs_with_file_mapping_reports_display_row_number__tc_bv_001(self, tmp_path):
+        """TC-BV-001: Missing file in the second data row reports SmartTable row 4."""
+        # Given: the first data row resolves and the second data row is missing its referenced file
+        csv_file = tmp_path / "smarttable_row_number.csv"
+        csv_file.write_text(
+            """File,Name
+inputdata1,basic/dataName
+present.dat,Sample1
+missing.dat,Sample2""",
+        )
+        output_dir = tmp_path / "output"
+        extracted_files = [Path("/temp/present.dat")]
+        st_file = SmartTableFile(csv_file)
+
+        # When: generating row CSV files checks the second data row
+        with pytest.raises(StructuredError) as exc_info:
+            st_file.generate_row_csvs_with_file_mapping(output_dir, extracted_files)
+
+        # Then: the reported row number matches the displayed SmartTable row number
+        assert str(exc_info.value) == "SmartTable row 4 references missing file in zip: inputdata1=missing.dat"
 
     def test_generate_row_csvs_no_extracted_files(self, tmp_path):
         """Test generating CSV files without extracted files."""

--- a/tests/test_smarttable_file.py
+++ b/tests/test_smarttable_file.py
@@ -6,6 +6,8 @@ Equivalence Partitioning:
 | `SmartTableFile.generate_row_csvs_with_file_mapping` | All `inputdata` values resolve to extracted files | Valid SmartTable references should preserve current behavior | Returns per-row CSV mappings with related files | `TC-EP-001` |
 | `SmartTableFile.generate_row_csvs_with_file_mapping` | One `inputdata` value does not exist in extracted files | Missing file should fail early with actionable context | Raises `StructuredError` including row, column, basename | `TC-EP-002` |
 | `SmartTableFile.generate_row_csvs_with_file_mapping` | Multiple `inputdata` values are missing across rows | UI needs one concise example while logs keep all details | Raises representative `StructuredError` and logs all mismatches | `TC-EP-003` |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | `inputdata` value exists but no zip was uploaded | Missing zip should be reported distinctly | Raises `StructuredError` explaining that an uploaded zip is required | `TC-EP-004` |
+| `SmartTableFile.generate_row_csvs_with_file_mapping` | Missing reference contains control characters | Log output must not allow multiline injection from SmartTable cells | Escapes control characters in log and display messages | `TC-EP-005` |
 |
 Boundary Value:
 | API | Boundary | Rationale | Expected Outcome | Test ID |
@@ -129,7 +131,7 @@ Sample1,データ1"""
             assert 'basic/dataName' in result.columns
 
 
-    def test_generate_row_csvs_with_file_mapping(self, tmp_path):
+    def test_generate_row_csvs_with_file_mapping__tc_ep_001(self, tmp_path):
         """TC-EP-001: Generating individual CSV files keeps related file mappings."""
         # Given: a SmartTable whose inputdata values all exist in extracted files
         csv_file = tmp_path / "smarttable_test.csv"
@@ -188,7 +190,7 @@ nested/results/missing_file.dat,Sample1""",
 
         # Then: the error exposes SmartTable row, column, and basename only
         error = exc_info.value
-        assert str(error) == "SmartTable row 3 references missing file in zip: inputdata1=missing_file.dat"
+        assert str(error) == "SmartTable row 3 references missing file in uploaded zip: inputdata1=missing_file.dat"
         assert "nested/results/missing_file.dat" not in str(error)
         assert error.eobj == [(3, "inputdata1", "nested/results/missing_file.dat")]
         assert "row 3: inputdata1=nested/results/missing_file.dat" in caplog.text
@@ -214,7 +216,7 @@ missing/third.dat,,Sample2""",
 
         # Then: the exception uses the first representative case and the log keeps all mismatches
         error = exc_info.value
-        assert str(error) == "SmartTable row 3 references missing file in zip: inputdata1=first.dat"
+        assert str(error) == "SmartTable row 3 references missing file in uploaded zip: inputdata1=first.dat"
         assert error.eobj == [
             (3, "inputdata1", "missing/first.dat"),
             (3, "inputdata2", "missing/second.dat"),
@@ -243,7 +245,66 @@ missing.dat,Sample2""",
             st_file.generate_row_csvs_with_file_mapping(output_dir, extracted_files)
 
         # Then: the reported row number matches the displayed SmartTable row number
-        assert str(exc_info.value) == "SmartTable row 4 references missing file in zip: inputdata1=missing.dat"
+        assert str(exc_info.value) == "SmartTable row 4 references missing file in uploaded zip: inputdata1=missing.dat"
+
+    def test_generate_row_csvs_with_file_mapping_requires_zip_for_inputdata__tc_ep_004(self, tmp_path, caplog):
+        """TC-EP-004: Missing zip input is reported separately from missing extracted files."""
+        # Given: a SmartTable row that references inputdata but no zip was uploaded
+        csv_file = tmp_path / "smarttable_requires_zip.csv"
+        csv_file.write_text(
+            """File,Name
+inputdata1,basic/dataName
+missing_file.dat,Sample1""",
+        )
+        output_dir = tmp_path / "output"
+        st_file = SmartTableFile(csv_file)
+        caplog.set_level("ERROR", logger="rdetoolkit.invoicefile._smarttable")
+
+        # When: generating row CSV files receives no extracted zip files
+        with pytest.raises(StructuredError) as exc_info:
+            st_file.generate_row_csvs_with_file_mapping(output_dir, None)
+
+        # Then: the error states that an uploaded zip is required
+        error = exc_info.value
+        assert str(error) == "SmartTable row 3 references inputdata1=missing_file.dat but no zip was uploaded"
+        assert error.eobj == [(3, "inputdata1", "missing_file.dat")]
+        assert "SmartTable references inputdata files but no zip was uploaded" in caplog.text
+        assert "row 3: inputdata1=missing_file.dat" in caplog.text
+
+    def test_generate_row_csvs_with_file_mapping_sanitizes_control_chars__tc_ep_005(self, tmp_path, caplog):
+        """TC-EP-005: Control characters from SmartTable cells are escaped in logs/messages."""
+        # Given: a SmartTable row whose inputdata column and value contain control characters
+        csv_file = tmp_path / "smarttable_sanitize.csv"
+        csv_file.write_text(
+            """File,Name
+inputdata1,basic/dataName
+placeholder.dat,Sample1""",
+        )
+        output_dir = tmp_path / "output"
+        st_file = SmartTableFile(csv_file)
+        st_file._data = pd.DataFrame(
+            [
+                {
+                    "inputdata1\nforged": "nested/\nmissing\rfile.dat",
+                    "basic/dataName": "Sample1",
+                },
+            ],
+        )
+        caplog.set_level("ERROR", logger="rdetoolkit.invoicefile._smarttable")
+
+        # When: generating row CSV files encounters the unresolved reference
+        with pytest.raises(StructuredError) as exc_info:
+            st_file.generate_row_csvs_with_file_mapping(output_dir, [])
+
+        # Then: control characters are escaped instead of being emitted raw into logs/messages
+        error = exc_info.value
+        assert (
+            str(error)
+            == "SmartTable row 3 references missing file in uploaded zip: inputdata1\\nforged=\\nmissing\\rfile.dat"
+        )
+        log_message = caplog.records[-1].getMessage()
+        assert "row 3: inputdata1\\nforged=nested/\\nmissing\\rfile.dat" in log_message
+        assert "row 3: inputdata1\nforged=nested/\nmissing\rfile.dat" not in log_message
 
     def test_generate_row_csvs_no_extracted_files(self, tmp_path):
         """Test generating CSV files without extracted files."""


### PR DESCRIPTION
## Summary

SmartTableの`inputdata`列で指定したファイルがアップロードされたzipファイル内に存在しない場合、従来は汎用的な「Error: ERROR: failed in data processing」が表示され、登録者が不足ファイルを特定できませんでした。本PRでは、データセット処理の開始前にファイル参照を検証し、具体的なエラーメッセージを表示するよう改善しました。

### Changes

- `SmartTableFile.generate_row_csvs_with_file_mapping()`で`inputdata...`列の参照ファイルを全行にわたって検証
- zip内に存在しない参照を検出した場合、`StructuredError`を送出（SmartTable上の行番号・列名・basenameを含む具体的なメッセージ）
- `job.failed`にはbasenameのみを含む短い文面（先頭の代表例1件）を記載
- 全件の詳細はloggerに出力し、複数の不一致をまとめて確認可能
- `StructuredError`を汎用メッセージで再ラップしないよう改善
- 制御文字のサニタイズ処理を追加

### Error message examples

`job.failed`:
```
ErrorCode=1
ErrorMessage=SmartTable row 3 references missing file in zip: inputdata1=doc1.txt
```

Log output (multiple mismatches):
```
SmartTable references files missing from the uploaded zip:
row 3: inputdata1=doc1.txt
row 4: inputdata1=doc2.txt
row 5: inputdata1=doc3.txt
```

### Testing

- `tests/test_smarttable_file.py`: 不足ファイル1件/複数件の`StructuredError`、SmartTable行番号変換、制御文字エスケープの回帰テスト
- `python -m pytest tests/test_smarttable_file.py tests/test_smarttable_checker.py -q`
- `uv run ruff check src/rdetoolkit/invoicefile/_smarttable.py tests/test_smarttable_file.py`

### References

- Issue: #462