### PR TITLE
fix: support uppercase image extensions in thumbnail copy

### DIFF
--- a/src/rdetoolkit/graph/renderers/plotly_renderer.py
+++ b/src/rdetoolkit/graph/renderers/plotly_renderer.py
@@ -122,7 +122,7 @@ class PlotlyRenderer:
             msg = f"x_cols ({len(x_cols)}) and y_cols ({len(y_cols)}) must match"
             raise ValueError(msg)
 
-        direction_cols = (
+        direction_cols: list[int | str | None] = (
             list(config.direction_cols)
             if config.direction_cols
             else [None] * len(y_cols)

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -53,11 +53,9 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
+    default_img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"]
     img_exts = (
-        [
-            ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff",
-            ".JPG", ".JPEG", ".PNG", ".GIF", ".BMP", ".SVG", ".WEBP", ".TIF", ".TIFF",
-        ]
+        default_img_exts + [ext.upper() for ext in default_img_exts]
         if img_ext is None
         else [img_ext]
     )

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -53,7 +53,14 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
-    img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp"] if img_ext is None else [img_ext]
+    img_exts = (
+        [
+            ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff",
+            ".JPG", ".JPEG", ".PNG", ".GIF", ".BMP", ".SVG", ".WEBP", ".TIF", ".TIFF",
+        ]
+        if img_ext is None
+        else [img_ext]
+    )
 
     img_paths_main = [glob(os.path.join(out_dir_main_img, "*" + ext)) for ext in img_exts]
     img_path_main = list(itertools.chain.from_iterable(img_paths_main))

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import os
 import shutil
 from glob import glob
@@ -53,15 +52,15 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
-    default_img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"]
-    img_exts = (
-        default_img_exts + [ext.upper() for ext in default_img_exts]
-        if img_ext is None
-        else [img_ext]
-    )
+    default_img_exts = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"}
+    normalized_img_exts = default_img_exts if img_ext is None else {img_ext.lower()}
 
-    img_paths_main = [glob(os.path.join(out_dir_main_img, "*" + ext)) for ext in img_exts]
-    img_path_main = list(itertools.chain.from_iterable(img_paths_main))
+    main_img_dir = Path(out_dir_main_img)
+    img_path_main = [
+        str(path)
+        for path in sorted(main_img_dir.iterdir())
+        if path.is_file() and path.suffix.lower() in normalized_img_exts
+    ]
 
     # When there are multiple images in the main image folder, copy one at the leading index as the representative image.
     __main_img_path: str = ""

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -155,25 +155,25 @@ def test_resize_image_exception_handling():
 
 @pytest.mark.parametrize("filename", ["dummy_main_img.JPG", "dummy_main_img.JPEG", "dummy_main_img.PNG"])
 def test_copy_images_to_thumbnail_uppercase_extensions(dummy_out_dir_thumb, dummy_out_dir_main, filename):
-    """大文字拡張子のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: 大文字拡張子のダミー画像ファイルをmain_imageに配置
+    """Test that files with uppercase extensions are copied to the thumbnail folder."""
+    # Given: a dummy image file with an uppercase extension in main_image
     with open(dummy_out_dir_main.joinpath(filename), "w") as f:
         f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
+    # When: copy_images_to_thumbnail is called
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    # Then: exactly one file should be copied to the thumbnail folder
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
     assert dummy_out_dir_thumb.joinpath(filename).exists()
 
 
 def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):
-    """小文字・大文字拡張子が混在する場合に代表画像が1つコピーされることを確認するテスト"""
-    # Given: 小文字・大文字混在のダミー画像ファイルをmain_imageに配置
+    """Test that only one representative image is copied when mixed-case extensions exist."""
+    # Given: dummy image files with both lowercase and uppercase extensions in main_image
     with open(dummy_out_dir_main.joinpath("dummy_main_img_lower.jpg"), "w") as f:
         f.write("dummy")
     with open(dummy_out_dir_main.joinpath("dummy_main_img_upper.JPG"), "w") as f:
         f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
+    # When: copy_images_to_thumbnail is called
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルのみがコピーされていること（代表画像は1つ）
+    # Then: only one representative image should be copied to the thumbnail folder
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -153,40 +153,17 @@ def test_resize_image_exception_handling():
             resize_image(image_path, width, height, output_path)
 
 
-def test_copy_images_to_thumbnail_uppercase_jpg(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .JPG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .JPG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPG"), "w") as f:
+@pytest.mark.parametrize("filename", ["dummy_main_img.JPG", "dummy_main_img.JPEG", "dummy_main_img.PNG"])
+def test_copy_images_to_thumbnail_uppercase_extensions(dummy_out_dir_thumb, dummy_out_dir_main, filename):
+    """大文字拡張子のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: 大文字拡張子のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath(filename), "w") as f:
         f.write("dummy")
     # When: copy_images_to_thumbnailを実行
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
     # Then: サムネイルフォルダに1つのファイルがコピーされていること
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPG").exists()
-
-
-def test_copy_images_to_thumbnail_uppercase_jpeg(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .JPEG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .JPEG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPEG"), "w") as f:
-        f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
-    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
-    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPEG").exists()
-
-
-def test_copy_images_to_thumbnail_uppercase_png(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .PNG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .PNG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.PNG"), "w") as f:
-        f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
-    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
-    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.PNG").exists()
+    assert dummy_out_dir_thumb.joinpath(filename).exists()
 
 
 def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -151,3 +151,52 @@ def test_resize_image_exception_handling():
 
         with pytest.raises(StructuredError, match="Failed to resize image: Mocked exception"):
             resize_image(image_path, width, height, output_path)
+
+
+def test_copy_images_to_thumbnail_uppercase_jpg(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .JPG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .JPG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPG").exists()
+
+
+def test_copy_images_to_thumbnail_uppercase_jpeg(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .JPEG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .JPEG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPEG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPEG").exists()
+
+
+def test_copy_images_to_thumbnail_uppercase_png(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .PNG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .PNG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.PNG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.PNG").exists()
+
+
+def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):
+    """小文字・大文字拡張子が混在する場合に代表画像が1つコピーされることを確認するテスト"""
+    # Given: 小文字・大文字混在のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img_lower.jpg"), "w") as f:
+        f.write("dummy")
+    with open(dummy_out_dir_main.joinpath("dummy_main_img_upper.JPG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルのみがコピーされていること（代表画像は1つ）
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1


### PR DESCRIPTION
### **User description**
## Related Issue
Closes #473

## Changes
- Added uppercase extension variants (`.JPG`, `.JPEG`, `.PNG`, `.GIF`, `.BMP`, `.SVG`, `.WEBP`) to the image extension list in `copy_images_to_thumbnail` function (`src/rdetoolkit/img2thumb.py`)
- Added `.tif`/`.tiff` and their uppercase variants (`.TIF`, `.TIFF`) which were previously missing from the extension list
- Added 4 test cases in `tests/test_thumbnail.py` to verify uppercase extension handling
- Fixed an unrelated mypy type error in `src/rdetoolkit/graph/renderers/plotly_renderer.py` (added explicit type annotation to `direction_cols`)

## Out of Scope
- Refactoring `glob`-based search to a case-insensitive approach (e.g., using `pathlib` with `suffix.lower()` normalization). The current fix is sufficient and minimal.
- SVG/WebP thumbnail resize support (these formats are copied but not resized by the Rust backend)

## Verification

- [x] CI tests pass successfully
- [x] No issues with the modified scripts
- [x] ruff lint passes
- [x] mypy type check passes
- [x] All 11 thumbnail tests pass (7 existing + 4 new)


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Fix case-insensitive image extension handling in thumbnail copy
  - Support uppercase and mixed-case extensions (e.g., `.JPG`, `.JPEG`, `.PNG`)
  - Add `.tif`/`.tiff` support for thumbnails

- Refactor directory scan for efficiency and reliability

- Add new and parametrized tests for uppercase/mixed-case extensions

- Fix mypy type annotation issue in plotly renderer


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["copy_images_to_thumbnail()"] -- "now matches extensions case-insensitively" --> B["Finds images with .jpg/.JPG/.tif/etc."]
  B -- "Copies representative image" --> C["Thumbnail folder"]
  D["test_thumbnail.py"] -- "adds tests for uppercase/mixed-case extensions" --> B
  E["plotly_renderer.py"] -- "adds explicit type annotation" --> F["mypy passes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>img2thumb.py</strong><dd><code>Refactor and fix case-insensitive image extension handling</code></dd></summary>
<hr>

src/rdetoolkit/img2thumb.py

<ul><li>Refactored image extension matching to be case-insensitive<br> <li> Added <code>.tif</code>/<code>.tiff</code> and uppercase extension support<br> <li> Replaced multiple glob calls with efficient directory scan</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/474/files#diff-b667b0b9af1955791b92db59863ca8b842f8345714d5caaa45f1e7317ef61885">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_thumbnail.py</strong><dd><code>Add tests for uppercase and mixed-case image extensions</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_thumbnail.py

<ul><li>Added parametrized tests for uppercase image extensions<br> <li> Added test for mixed-case extension handling<br> <li> Improved test coverage for thumbnail copying logic</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/474/files#diff-966fdabd28c9ebfa4499d0c6ed3bceb40412946ff5ccd712ac105577bbb44d20">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plotly_renderer.py</strong><dd><code>Add type annotation to fix mypy error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/graph/renderers/plotly_renderer.py

<ul><li>Added explicit type annotation for <code>direction_cols</code><br> <li> Fixed mypy type error</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/474/files#diff-c54a83b998bffef2022b93312223197f8756299623c2e9f6463d456512e8e750">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

