### PR TITLE
fix: set sampleId to None instead of empty string for new sample registration in SmartTable

### DIFF
--- a/src/rdetoolkit/processing/processors/invoice.py
+++ b/src/rdetoolkit/processing/processors/invoice.py
@@ -659,7 +659,7 @@ class SmartTableInvoiceInitializer(Processor):
 
         Fields cleared:
 
-        - ``sample.sampleId`` → ``""`` (empty string indicates a new sample)
+        - ``sample.sampleId`` → ``None`` (None indicates new sample registration; empty string causes server-side error)
         - ``sample.description`` → ``None``
         - ``sample.composition`` → ``None``
         - ``sample.referenceUrl`` → ``None``
@@ -672,7 +672,7 @@ class SmartTableInvoiceInitializer(Processor):
         """
         sample_section = invoice_data.setdefault("sample", {})
 
-        sample_section["sampleId"] = ""
+        sample_section["sampleId"] = None
         for field in ("description", "composition", "referenceUrl"):
             sample_section[field] = None
 

--- a/tests/processing/processors/test_invoice_smarttable.py
+++ b/tests/processing/processors/test_invoice_smarttable.py
@@ -493,7 +493,7 @@ class TestSmartTableInvoiceInitializerIntegration:
         with open(context.invoice_dst_filepath) as f:
             output = json.load(f)
 
-        assert output["sample"]["sampleId"] == ""
+        assert output["sample"]["sampleId"] is None
         assert output["sample"]["description"] is None
         assert output["sample"]["composition"] is None
         assert output["sample"]["referenceUrl"] is None
@@ -574,8 +574,46 @@ class TestSmartTableInvoiceInitializerIntegration:
             output = json.load(f)
 
         # Then: sampleId is cleared (new-sample) AND ownerId = basic.dataOwnerId (#389)
-        assert output["sample"]["sampleId"] == ""
+        assert output["sample"]["sampleId"] is None
         assert output["sample"]["ownerId"] == expected_owner_id
+
+    def test_new_sample_sampleid_is_none_not_empty_string__issue_470(self, smarttable_processing_context):
+        """Issue #470: sample/names given without sample/sampleId must set sampleId to None, not empty string.
+
+        An empty-string sampleId causes a server-side error
+        ("存在しない試料IDが指定されました").
+        None correctly indicates new sample registration intent.
+        """
+        # Given: original invoice has a dummy sampleId and filled dummy fields
+        processor = SmartTableInvoiceInitializer()
+        context = smarttable_processing_context
+        SmartTableInvoiceInitializer._BASE_INVOICE_CACHE.clear()
+        self._setup_invoice_with_dummy_sample(context)
+
+        # CSV has sample/names but no sample/sampleId column (new sample registration intent)
+        csv_data = pd.DataFrame({
+            "sample/names": ["Brand New Sample"],
+            "basic/dataName": ["Issue470 Data"],
+        })
+        csv_path = context.smarttable_rowfile
+        assert csv_path is not None
+        csv_data.to_csv(csv_path, index=False)
+
+        # When: processing (new sample registration: names present, sampleId absent)
+        processor.process(context)
+
+        # Then: sampleId must be None (not empty string "")
+        with open(context.invoice_dst_filepath) as f:
+            output = json.load(f)
+
+        assert output["sample"]["sampleId"] is None, (
+            "sampleId should be None for new sample registration, not empty string. "
+            "Empty string causes server-side error: '存在しない試料IDが指定されました'"
+        )
+        assert output["sample"]["sampleId"] != "", (
+            "sampleId must not be empty string; this causes the RDE server error in Issue #470"
+        )
+        assert output["sample"]["names"] == ["Brand New Sample"]
 
 
 class TestSmartTableEarlyExitProcessorIntegration:

--- a/tests/test_smarttable_invoice_initializer.py
+++ b/tests/test_smarttable_invoice_initializer.py
@@ -1,31 +1,33 @@
 """Test SmartTableInvoiceInitializer behavior with equivalence partitioning and boundary values.
 
 Equivalence Partitioning:
-| API                                   | Input/State Partition                                         | Rationale                                                              | Expected Outcome                                                      | Test ID       |
-| ------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------- |
-| `SmartTableInvoiceInitializer.process` | Multiple SmartTable rows with fresh processors per row        | Pipelines re-instantiate processors for each row                       | sample.ownerId is set to basic.dataOwnerId                            | `TC-EP-001`   |
-| `SmartTableInvoiceInitializer.process` | Missing SmartTable row CSV in SmartTable mode                  | Invalid SmartTable input should be rejected                             | Raises `StructuredError`                                              | `TC-EP-002`   |
-| `SmartTableInvoiceInitializer.process` | basic.dataOwnerId is missing in original invoice               | Defensive handling when required field is absent                       | Logs warning, preserves original sample.ownerId                       | `TC-EP-003`   |
-| `SmartTableInvoiceInitializer.process` | SmartTable CSV contains sample/ownerId column                  | CSV value should take precedence when explicitly specified             | sample.ownerId uses CSV value, not basic.dataOwnerId                  | `TC-EP-004`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId column absent          | New sample registration; dummy sampleId must not be inherited          | sampleId→"", description/composition/referenceUrl→None, attr values→None | `TC-EP-005`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId = UUID                 | Explicit reference to existing sample; no clearing should occur        | sampleId preserved, other fields unchanged                            | `TC-EP-006`   |
-| `SmartTableInvoiceInitializer.process` | Neither sample/names nor sample/sampleId specified             | No sample intent; original invoice sample fields must be preserved     | All original sample fields unchanged                                  | `TC-EP-007`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId column present but ""  | Explicit empty sampleId treated same as absent; new sample             | sampleId→"", other fields cleared                                     | `TC-EP-008`   |
-| `SmartTableInvoiceInitializer.process` | sample/names only; Issue #389 ownerId correction still applies | Clearing must not break existing ownerId auto-assignment logic         | sample.ownerId = basic.dataOwnerId after clearing                     | `TC-EP-009`   |
-| `SmartTableInvoiceInitializer.process` | sample/names with fixed-header blank sample columns            | New sample clearing must survive the generic blank-cell clearing pass  | sampleId/description and attribute structures remain cleared, not removed | `TC-EP-010` |
-| `SmartTableInvoiceInitializer.process` | sample/names + UUID + blank sample field                       | Existing sample reference path must keep generic blank-cell clearing   | Explicit sampleId kept; blank sample field is removed                 | `TC-EP-011`   |
-| `SmartTableInvoiceInitializer.process` | Original invoice has `sample.generalAttributes = null`         | SmartTable must normalize null containers before term assignment       | `sample/generalAttributes.<termId>` is written without error          | `TC-EP-012`   |
-| `SmartTableInvoiceInitializer.process` | Original invoice has `sample.specificAttributes = null`        | SmartTable must normalize null containers before class/term assignment | `sample/specificAttributes.<classId>.<termId>` is written without error | `TC-EP-013` |
+
+| Input/State Partition                                   | Expected Outcome                                       | Test ID     |
+| ------------------------------------------------------- | ------------------------------------------------------ | ----------- |
+| Multiple SmartTable rows with fresh processors per row  | sample.ownerId is set to basic.dataOwnerId             | TC-EP-001   |
+| Missing SmartTable row CSV in SmartTable mode           | Raises StructuredError                                 | TC-EP-002   |
+| basic.dataOwnerId is missing in original invoice        | Logs warning, preserves original sample.ownerId        | TC-EP-003   |
+| SmartTable CSV contains sample/ownerId column           | sample.ownerId uses CSV value, not basic.dataOwnerId   | TC-EP-004   |
+| sample/names specified, sample/sampleId absent          | sampleId=None, other dummy fields cleared              | TC-EP-005   |
+| sample/names specified, sample/sampleId = UUID          | sampleId preserved, other fields unchanged             | TC-EP-006   |
+| Neither sample/names nor sample/sampleId specified      | All original sample fields unchanged                   | TC-EP-007   |
+| sample/names given, sample/sampleId column present=""  | sampleId=None, other fields cleared                    | TC-EP-008   |
+| sample/names only; Issue #389 ownerId correction        | sample.ownerId = basic.dataOwnerId after clearing      | TC-EP-009   |
+| sample/names with fixed-header blank sample columns     | Cleared structures remain, not removed                 | TC-EP-010   |
+| sample/names + UUID + blank sample field                | Explicit sampleId kept; blank field removed            | TC-EP-011   |
+| Original invoice has sample.generalAttributes = null   | generalAttributes.<termId> written without error       | TC-EP-012   |
+| Original invoice has sample.specificAttributes = null  | specificAttributes.<classId>.<termId> written ok       | TC-EP-013   |
 
 Boundary Value:
-| API                                   | Boundary                                       | Rationale                                               | Expected Outcome                            | Test ID       |
-| ------------------------------------- | ---------------------------------------------- | ------------------------------------------------------- | ------------------------------------------- | ------------- |
-| `SmartTableInvoiceInitializer.process` | First invocation with SmartTable row           | Automatic ownerId assignment from basic.dataOwnerId     | sample.ownerId is set to basic.dataOwnerId  | `TC-BV-001`   |
-| `SmartTableInvoiceInitializer.process` | `smarttable_file` is `None`                     | SmartTable mode should be enforced                      | Raises `ValueError`                         | `TC-BV-002`   |
-| `SmartTableInvoiceInitializer.process` | basic.dataOwnerId is empty string               | Defensive handling when field is empty                  | Logs warning, preserves original ownerId    | `TC-BV-003`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: empty string ""       | Empty string is not a valid sampleId reference          | Treated as absent; new sample clearing runs | `TC-BV-004`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: valid UUID string     | UUID present means explicit reference to existing sample| No clearing; sampleId preserved             | `TC-BV-005`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: whitespace-only "   " | Whitespace-only must not be treated as valid sampleId   | Treated as absent; new sample clearing runs | `TC-BV-006`   |
+
+| Boundary                                     | Expected Outcome                            | Test ID   |
+| -------------------------------------------- | ------------------------------------------- | --------- |
+| First invocation with SmartTable row         | sample.ownerId set to basic.dataOwnerId     | TC-BV-001 |
+| smarttable_file is None                      | Raises ValueError                           | TC-BV-002 |
+| basic.dataOwnerId is empty string            | Logs warning, preserves original ownerId    | TC-BV-003 |
+| sample/sampleId = empty string ""            | Treated as absent; new sample clearing runs | TC-BV-004 |
+| sample/sampleId = valid UUID string          | No clearing; sampleId preserved             | TC-BV-005 |
+| sample/sampleId = whitespace-only "   "      | Treated as absent; new sample clearing runs | TC-BV-006 |
 """
 
 from __future__ import annotations
@@ -510,7 +512,7 @@ def test_smarttable_clears_dummy_sample_when_names_only__tc_ep_005(tmp_path: Pat
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: dummy sampleId is cleared
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     # Then: dummy text fields are cleared
     assert output["sample"]["description"] is None
     assert output["sample"]["composition"] is None
@@ -578,7 +580,7 @@ def test_smarttable_clears_dummy_sample_when_sampleid_empty__tc_ep_008(tmp_path:
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: new-sample clearing applies because sampleId was not a non-empty value
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     assert output["sample"]["names"] == ["Brand New"]
 
@@ -596,7 +598,7 @@ def test_smarttable_ownerid_corrected_after_new_sample_clearing__tc_ep_009(tmp_p
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: sampleId is cleared (new-sample clearing ran)
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     # Then: ownerId is set to basic.dataOwnerId (Issue #389 logic preserved)
     assert output["sample"]["ownerId"] == expected_owner_id
 
@@ -627,7 +629,7 @@ def test_smarttable_preserves_cleared_sample_fields_for_blank_fixed_headers__tc_
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: cleared scalar fields remain in their normalized empty form
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     # Then: cleared attribute entries are preserved instead of being deleted
     assert any(
@@ -733,7 +735,7 @@ def test_smarttable_empty_sampleid_boundary_triggers_clearing__tc_bv_004(tmp_pat
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: empty sampleId in CSV is treated as "no sampleId" → clearing applies
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
 
 
@@ -777,6 +779,6 @@ def test_smarttable_whitespace_sampleid_triggers_clearing__tc_bv_006(tmp_path: P
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: whitespace-only sampleId is equivalent to absent → new-sample clearing applies
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     assert output["sample"]["names"] == ["Brand New BV-006"]


### PR DESCRIPTION
### **User description**
## Related Issue
- #470

## Changes
- Change `_clear_sample_for_new_registration()` to set `sampleId = None` instead of `sampleId = ""`
- Update docstring to clarify that `None` indicates new sample registration and empty string causes server-side error
- Update existing test assertions from `== ""` to `is None` in both `test_invoice_smarttable.py` and `test_smarttable_invoice_initializer.py`
- Add regression test `test_new_sample_sampleid_is_none_not_empty_string__issue_470`

## Out of Scope
- Changes to `_clear_mapping_key` logic (separate code path, not affected)
- Server-side validation changes

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix new sample registration to set sampleId to None, not empty string

- Update processor logic and docstrings for correct sampleId handling

- Refactor and extend tests to assert sampleId is None for new samples

- Add regression test for Issue #470 (server error on empty string sampleId)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SmartTable new sample registration"] -- "previously set sampleId = ''" --> B["Server error: invalid sampleId"]
  A -- "now sets sampleId = None" --> C["Correct new sample registration"]
  B -- "fix applied" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>invoice.py</strong><dd><code>Set sampleId to None for new sample registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/rdetoolkit/processing/processors/invoice.py

<ul><li>Change sampleId clearing logic to set None instead of empty string<br> <li> Update docstring to clarify correct sampleId handling</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/475/files#diff-2bad8b90d4f46b258fc1d0835a5b4a88ac12e041809e82712f0450b5bb663676">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_invoice_smarttable.py</strong><dd><code>Update and extend tests for sampleId=None logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/processing/processors/test_invoice_smarttable.py

<ul><li>Update assertions to expect sampleId is None, not empty string<br> <li> Add regression test for Issue #470 (sampleId None vs empty string)</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/475/files#diff-15640c71a36f52ec9f869387a3dd9cfa2a25e13cd02fcd72adba837e0b41d171">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_smarttable_invoice_initializer.py</strong><dd><code>Refactor tests to assert sampleId is None for new samples</code></dd></summary>
<hr>

tests/test_smarttable_invoice_initializer.py

<ul><li>Refactor test assertions to expect sampleId is None for new samples<br> <li> Update test case documentation to reflect new logic</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/475/files#diff-91a77f650ffa7f8de530c49e70db76a8af0ea949ab179da8ecfe2764aa4b6ce4">+31/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

