### PR TITLE
docs: add v1.6.3 changelog for #470 and #473

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### SmartTable New Sample Registration sampleId Fix (#470)
+
+Fixed a bug where `sampleId` was set to an empty string `""` instead of `None` during new sample registration in SmartTable mode. The empty string caused a server-side error "存在しない試料IDが指定されました" (non-existent sample ID specified). Now `_clear_sample_for_new_registration()` sets `sampleId` to `None`, which correctly triggers new sample creation.
+
+#### Support Uppercase Image Extensions in Thumbnail Copy (#473)
+
+Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added uppercase variants and `.tif`/`.tiff` support to the extension list. Also used single directory scan with case-insensitive extension matching for improved efficiency.
+
 #### SmartTable Missing File Reference Error Improvement (#462)
 
 Improved error messages when SmartTable `inputdata` column references files that do not exist in the uploaded zip. Previously, a generic "ERROR: failed in data processing" was shown. Now raises `StructuredError` with the specific SmartTable row number, column name, and file basename. Full details of all missing references are logged for multi-file diagnosis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Fixed a bug where `sampleId` was set to an empty string `""` instead of `None` d
 
 #### Support Uppercase Image Extensions in Thumbnail Copy (#473)
 
-Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added uppercase variants and `.tif`/`.tiff` support to the extension list. Also used single directory scan with case-insensitive extension matching for improved efficiency.
+Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added `.tif`/`.tiff` support and switched to a single directory scan that normalizes file suffixes to lowercase for case-insensitive extension matching, improving both correctness and efficiency.
 
 #### SmartTable Missing File Reference Error Improvement (#462)
 

--- a/docs/releases/index.en.md
+++ b/docs/releases/index.en.md
@@ -53,9 +53,8 @@
 
 **Changes**:
 
-- Added uppercase extension variants (`.JPG`, `.JPEG`, `.PNG`, `.GIF`, `.BMP`, `.SVG`, `.WEBP`) to the image extension list in `copy_images_to_thumbnail` function (`src/rdetoolkit/img2thumb.py`)
-- Added `.tif`/`.tiff` and their uppercase variants (`.TIF`, `.TIFF`) which were previously missing from the extension list
-- Refactored to use single directory scan with case-insensitive extension matching for improved efficiency
+- Refactored `copy_images_to_thumbnail` (`src/rdetoolkit/img2thumb.py`) to use a single directory scan with case-insensitive extension matching
+- Added `.tif`/`.tiff` support, which was previously missing from the image extension list
 - Added 4 test cases in `tests/test_thumbnail.py` to verify uppercase extension handling
 - Fixed an unrelated mypy type error in `src/rdetoolkit/graph/renderers/plotly_renderer.py`
 

--- a/docs/releases/index.en.md
+++ b/docs/releases/index.en.md
@@ -4,6 +4,7 @@
 
 | Version | Release Date | Key Changes | Details |
 | ------- | ------------ | ----------- | ------- |
+| v1.6.3  | 2026-04-13   | Fix SmartTable new sample `sampleId` set to None instead of empty string / Support uppercase image extensions in thumbnail copy | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2  | 2026-03-16   | Fix silent inheritance of dummy sampleId when SmartTable specifies `sample/names` / Improve error messages for missing SmartTable file references in zip | [v1.6.2](#v162-2026-03-16) |
 | v1.6.1  | 2026-03-10   | chardet public API migration (Python 3.14 compat) / SmartTable custom field type cast fix | [v1.6.1](#v161-2026-03-10) |
 | v1.6.0  | 2026-02-18   | **BREAKING**: Python 3.9 support dropped (minimum 3.10+) / direct `pytz` dependency removed / `gen-invoice` command added / AI agent guide embedded / Agent Skills added | [v1.6.0](#v160-2026-02-18) |
@@ -22,6 +23,54 @@
 | v1.2.0  | 2025-04-14   | MinIO integration / Archive generation / Report tooling | [v1.2.0](#v120-2025-04-14) |
 
 # Release Details
+
+## v1.6.3 (2026-04-13)
+
+!!! info "References"
+    - Key issues: [#470](https://github.com/nims-mdpf/rdetoolkit/issues/470), [#473](https://github.com/nims-mdpf/rdetoolkit/issues/473)
+    - Pull requests: [#474](https://github.com/nims-mdpf/rdetoolkit/pull/474), [#475](https://github.com/nims-mdpf/rdetoolkit/pull/475)
+
+#### Highlights
+- Fixed SmartTable new sample registration setting `sampleId` to empty string instead of `None`, which caused a server-side "non-existent sample ID" error
+- Fixed uppercase image file extensions (`.JPG`, `.JPEG`, `.PNG`) not being copied to the thumbnail folder on case-sensitive file systems
+
+### Bug Fixes
+
+#### SmartTable New Sample Registration sampleId Fix (Issue #470)
+
+**Problem**: When registering a new sample via SmartTable, `_clear_sample_for_new_registration()` set `sampleId` to an empty string `""`. The server interpreted this as a reference to a non-existent sample, resulting in the error "存在しない試料IDが指定されました" (non-existent sample ID specified).
+
+**Changes**:
+
+- Changed `_clear_sample_for_new_registration()` to set `sampleId = None` instead of `sampleId = ""` in `src/rdetoolkit/processing/processors/invoice.py`
+- Updated docstring to clarify that `None` indicates new sample registration and empty string causes server-side error
+- Updated existing test assertions from `== ""` to `is None`
+- Added regression test `test_new_sample_sampleid_is_none_not_empty_string__issue_470`
+
+#### Support Uppercase Image Extensions in Thumbnail Copy (Issue #473)
+
+**Problem**: Image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the `data/thumbnail` folder. Python's `glob.glob()` depends on the OS file system's case-sensitivity. On Linux (ext4) and Docker containers (case-sensitive), uppercase extensions did not match the lowercase-only extension list. macOS (APFS, case-insensitive by default) did not exhibit this issue, making it harder to detect during development.
+
+**Changes**:
+
+- Added uppercase extension variants (`.JPG`, `.JPEG`, `.PNG`, `.GIF`, `.BMP`, `.SVG`, `.WEBP`) to the image extension list in `copy_images_to_thumbnail` function (`src/rdetoolkit/img2thumb.py`)
+- Added `.tif`/`.tiff` and their uppercase variants (`.TIF`, `.TIFF`) which were previously missing from the extension list
+- Refactored to use single directory scan with case-insensitive extension matching for improved efficiency
+- Added 4 test cases in `tests/test_thumbnail.py` to verify uppercase extension handling
+- Fixed an unrelated mypy type error in `src/rdetoolkit/graph/renderers/plotly_renderer.py`
+
+### Testing
+
+- `tests/processing/processors/test_invoice_smarttable.py`: Updated assertions and added regression test for Issue #470
+- `tests/test_smarttable_invoice_initializer.py`: Updated assertions from `== ""` to `is None`
+- `tests/test_thumbnail.py`: Added 4 new test cases for uppercase extension handling
+
+### Migration / Compatibility
+
+- If your workflow relies on `sampleId` being an empty string `""` after `_clear_sample_for_new_registration()`, it is now `None`. This is the correct behavior for new sample registration on the RDE server
+- Thumbnail copy now supports uppercase image extensions (`.JPG`, `.JPEG`, `.PNG`, etc.) and `.tif`/`.tiff` formats, which were previously ignored on case-sensitive file systems. No user action required
+
+---
 
 ## v1.6.2 (2026-03-16)
 

--- a/docs/releases/index.ja.md
+++ b/docs/releases/index.ja.md
@@ -53,8 +53,8 @@
 
 **修正内容**:
 
-- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で画像拡張子リストに大文字バリアント（`.JPG`、`.JPEG`、`.PNG`、`.GIF`、`.BMP`、`.SVG`、`.WEBP`）を追加
-- これまで拡張子リストに含まれていなかった`.tif`/`.tiff`とその大文字バリアント（`.TIF`、`.TIFF`）を追加
+- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で、`path.suffix.lower()`によるcase-insensitiveな拡張子判定に変更
+- これまで対応対象に含まれていなかった`.tif`/`.tiff`を追加し、これらもcase-insensitiveに判定されるよう修正
 - 単一ディレクトリスキャンによるcase-insensitive拡張子マッチングにリファクタリングし、効率を改善
 - `tests/test_thumbnail.py`に大文字拡張子処理を検証するテストケース4件を追加
 - `src/rdetoolkit/graph/renderers/plotly_renderer.py`の既存mypy型エラーを修正（Issue外）

--- a/docs/releases/index.ja.md
+++ b/docs/releases/index.ja.md
@@ -4,6 +4,7 @@
 
 | バージョン | リリース日 | 主な変更点 | 詳細セクション |
 | ---------- | ---------- | ---------- | -------------- |
+| v1.6.3     | 2026-04-13 | SmartTable新規試料登録時の`sampleId`を空文字ではなく`None`に修正 / サムネイルコピーで大文字画像拡張子をサポート | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2     | 2026-03-16 | SmartTableで`sample/names`指定時にダミー試料の`sampleId`が黙って継承される問題を修正 / SmartTableのファイル参照がzip内に存在しない場合のエラーメッセージ改善 | [v1.6.2](#v162-2026-03-16) |
 | v1.6.1     | 2026-03-10 | chardet公開API移行（Python 3.14互換） / SmartTableカスタムフィールドの型キャスト修正 | [v1.6.1](#v161-2026-03-10) |
 | v1.6.0     | 2026-02-18 | **破壊的変更**: Python 3.9サポート終了（最小バージョン3.10+） / `pytz`の直接依存を削除 / `gen-invoice`コマンド追加 / AIエージェントガイド埋め込み / Agent Skills追加 | [v1.6.0](#v160-2026-02-18) |
@@ -22,6 +23,54 @@
 | v1.2.0     | 2025-04-14 | MinIO対応 / アーカイブ生成 / レポート生成 | [v1.2.0](#v120-2025-04-14) |
 
 # リリース詳細
+
+## v1.6.3 (2026-04-13)
+
+!!! info "参照"
+    - 主な課題: [#470](https://github.com/nims-mdpf/rdetoolkit/issues/470), [#473](https://github.com/nims-mdpf/rdetoolkit/issues/473)
+    - プルリクエスト: [#474](https://github.com/nims-mdpf/rdetoolkit/pull/474), [#475](https://github.com/nims-mdpf/rdetoolkit/pull/475)
+
+#### ハイライト
+- SmartTableで新規試料を登録する際に`sampleId`が空文字`""`に設定され、サーバー側で「存在しない試料IDが指定されました」エラーが発生する問題を修正
+- 大文字拡張子の画像ファイル（`.JPG`、`.JPEG`、`.PNG`）がcase-sensitiveなファイルシステム上でサムネイルフォルダにコピーされない問題を修正
+
+### バグ修正
+
+#### SmartTable新規試料登録時のsampleId修正 (Issue #470)
+
+**問題**: SmartTableで新規試料を登録する際、`_clear_sample_for_new_registration()`が`sampleId`を空文字`""`に設定していました。サーバーはこれを存在しない試料IDへの参照と解釈し、「存在しない試料IDが指定されました」というエラーが発生していました。
+
+**修正内容**:
+
+- `src/rdetoolkit/processing/processors/invoice.py`の`_clear_sample_for_new_registration()`で`sampleId`を`""`ではなく`None`に設定するよう変更
+- `None`が新規試料登録を意味し、空文字がサーバーエラーを引き起こすことをdocstringに明記
+- 既存テストのアサーションを`== ""`から`is None`に修正
+- 回帰テスト`test_new_sample_sampleid_is_none_not_empty_string__issue_470`を追加
+
+#### サムネイルコピーでの大文字画像拡張子サポート (Issue #473)
+
+**問題**: 大文字拡張子の画像ファイル（`.JPG`、`.JPEG`、`.PNG`）が`data/thumbnail`フォルダにコピーされていませんでした。Pythonの`glob.glob()`はOSのファイルシステムのcase-sensitivityに依存しており、Linux（ext4）やDockerコンテナ（case-sensitive）では小文字のみの拡張子リストに大文字拡張子がマッチしませんでした。macOS（APFS、デフォルトでcase-insensitive）では問題が発現しないため、開発時に検出が困難でした。
+
+**修正内容**:
+
+- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で画像拡張子リストに大文字バリアント（`.JPG`、`.JPEG`、`.PNG`、`.GIF`、`.BMP`、`.SVG`、`.WEBP`）を追加
+- これまで拡張子リストに含まれていなかった`.tif`/`.tiff`とその大文字バリアント（`.TIF`、`.TIFF`）を追加
+- 単一ディレクトリスキャンによるcase-insensitive拡張子マッチングにリファクタリングし、効率を改善
+- `tests/test_thumbnail.py`に大文字拡張子処理を検証するテストケース4件を追加
+- `src/rdetoolkit/graph/renderers/plotly_renderer.py`の既存mypy型エラーを修正（Issue外）
+
+### テスト
+
+- `tests/processing/processors/test_invoice_smarttable.py`: アサーション更新およびIssue #470の回帰テストを追加
+- `tests/test_smarttable_invoice_initializer.py`: アサーションを`== ""`から`is None`に更新
+- `tests/test_thumbnail.py`: 大文字拡張子処理のテストケース4件を追加
+
+### 移行 / 互換性
+
+- `_clear_sample_for_new_registration()`後の`sampleId`が空文字`""`から`None`に変更されます。これはRDEサーバーでの新規試料登録に必要な正しい動作です
+- サムネイルコピーが大文字画像拡張子（`.JPG`、`.JPEG`、`.PNG`等）と`.tif`/`.tiff`形式をサポートするようになりました。case-sensitiveなファイルシステムで以前無視されていたファイルもコピーされます。ユーザーの対応は不要です
+
+---
 
 ## v1.6.2 (2026-03-16)
 


### PR DESCRIPTION
### **User description**
## Summary
- Added v1.6.3 release notes to `CHANGELOG.md`, `docs/releases/index.en.md`, and `docs/releases/index.ja.md`
- Covers two bug fixes merged into develop/v163:
  - **#470**: Fix SmartTable new sample registration `sampleId` set to `None` instead of empty string
  - **#473**: Support uppercase image extensions (`.JPG`, `.JPEG`, `.PNG`) in thumbnail copy

## Related Issues
- #470
- #473

## Test plan
- [ ] Verify changelog entries render correctly in MkDocs documentation
- [ ] Confirm version table links resolve to correct detail sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Added v1.6.3 release notes to changelog and docs
  - Documents SmartTable `sampleId` bug fix (#470)
  - Documents uppercase image extension bug fix (#473)

- Updated English and Japanese release index tables for v1.6.3

- Detailed highlights, bug fixes, and migration notes for both issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CHANGELOG.md"] -- "Add v1.6.3 release notes" --> B["docs/releases/index.en.md"]
  A -- "Add v1.6.3 release notes" --> C["docs/releases/index.ja.md"]
  B -- "Update version table and details" --> D["Document bug fixes #470, #473"]
  C -- "Update version table and details" --> E["Document bug fixes #470, #473"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add v1.6.3 release notes with bug fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added v1.6.3 section with detailed bug fix notes<br> <li> Describes SmartTable <code>sampleId</code> and image extension issues and fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/477/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.en.md</strong><dd><code>Document v1.6.3 release and bug fixes (EN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/releases/index.en.md

<ul><li>Added v1.6.3 to release table and details section<br> <li> Summarized and detailed both major bug fixes<br> <li> Included migration and testing notes for v1.6.3</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/477/files#diff-4927398bbc5416d2373f7d5ab4f4dbc448bd1d02438f0017b365b025d50e3095">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ja.md</strong><dd><code>Document v1.6.3 release and bug fixes (JA)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/releases/index.ja.md

<ul><li>Added v1.6.3 to Japanese release table and details<br> <li> Summarized and detailed both major bug fixes in Japanese<br> <li> Included migration and testing notes for v1.6.3</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/477/files#diff-918a15bad39655ff5c737a14fdb798f5f9befb7357cdf4d61bab286a791e64bc">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

