### PR TITLE
Release v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-04-13
+
 ### Fixed
 
 #### SmartTable New Sample Registration sampleId Fix (#470)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### SmartTable New Sample Registration sampleId Fix (#470)
+
+Fixed a bug where `sampleId` was set to an empty string `""` instead of `None` during new sample registration in SmartTable mode. The empty string caused a server-side error "存在しない試料IDが指定されました" (non-existent sample ID specified). Now `_clear_sample_for_new_registration()` sets `sampleId` to `None`, which correctly triggers new sample creation.
+
+#### Support Uppercase Image Extensions in Thumbnail Copy (#473)
+
+Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added uppercase variants and `.tif`/`.tiff` support to the extension list. Also used single directory scan with case-insensitive extension matching for improved efficiency.
+
 #### SmartTable Missing File Reference Error Improvement (#462)
 
 Improved error messages when SmartTable `inputdata` column references files that do not exist in the uploaded zip. Previously, a generic "ERROR: failed in data processing" was shown. Now raises `StructuredError` with the specific SmartTable row number, column name, and file basename. Full details of all missing references are logged for multi-file diagnosis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Fixed a bug where `sampleId` was set to an empty string `""` instead of `None` d
 
 #### Support Uppercase Image Extensions in Thumbnail Copy (#473)
 
-Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added uppercase variants and `.tif`/`.tiff` support to the extension list. Also used single directory scan with case-insensitive extension matching for improved efficiency.
+Fixed a bug where image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the thumbnail folder. On case-sensitive file systems (Linux/Docker), `glob` pattern matching only found lowercase extensions. Added `.tif`/`.tiff` support and switched to a single directory scan that normalizes file suffixes to lowercase for case-insensitive extension matching, improving both correctness and efficiency.
 
 #### SmartTable Missing File Reference Error Improvement (#462)
 

--- a/docs/releases/index.en.md
+++ b/docs/releases/index.en.md
@@ -53,9 +53,8 @@
 
 **Changes**:
 
-- Added uppercase extension variants (`.JPG`, `.JPEG`, `.PNG`, `.GIF`, `.BMP`, `.SVG`, `.WEBP`) to the image extension list in `copy_images_to_thumbnail` function (`src/rdetoolkit/img2thumb.py`)
-- Added `.tif`/`.tiff` and their uppercase variants (`.TIF`, `.TIFF`) which were previously missing from the extension list
-- Refactored to use single directory scan with case-insensitive extension matching for improved efficiency
+- Refactored `copy_images_to_thumbnail` (`src/rdetoolkit/img2thumb.py`) to use a single directory scan with case-insensitive extension matching
+- Added `.tif`/`.tiff` support, which was previously missing from the image extension list
 - Added 4 test cases in `tests/test_thumbnail.py` to verify uppercase extension handling
 - Fixed an unrelated mypy type error in `src/rdetoolkit/graph/renderers/plotly_renderer.py`
 

--- a/docs/releases/index.en.md
+++ b/docs/releases/index.en.md
@@ -4,6 +4,7 @@
 
 | Version | Release Date | Key Changes | Details |
 | ------- | ------------ | ----------- | ------- |
+| v1.6.3  | 2026-04-13   | Fix SmartTable new sample `sampleId` set to None instead of empty string / Support uppercase image extensions in thumbnail copy | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2  | 2026-03-16   | Fix silent inheritance of dummy sampleId when SmartTable specifies `sample/names` / Improve error messages for missing SmartTable file references in zip | [v1.6.2](#v162-2026-03-16) |
 | v1.6.1  | 2026-03-10   | chardet public API migration (Python 3.14 compat) / SmartTable custom field type cast fix | [v1.6.1](#v161-2026-03-10) |
 | v1.6.0  | 2026-02-18   | **BREAKING**: Python 3.9 support dropped (minimum 3.10+) / direct `pytz` dependency removed / `gen-invoice` command added / AI agent guide embedded / Agent Skills added | [v1.6.0](#v160-2026-02-18) |
@@ -22,6 +23,54 @@
 | v1.2.0  | 2025-04-14   | MinIO integration / Archive generation / Report tooling | [v1.2.0](#v120-2025-04-14) |
 
 # Release Details
+
+## v1.6.3 (2026-04-13)
+
+!!! info "References"
+    - Key issues: [#470](https://github.com/nims-mdpf/rdetoolkit/issues/470), [#473](https://github.com/nims-mdpf/rdetoolkit/issues/473)
+    - Pull requests: [#474](https://github.com/nims-mdpf/rdetoolkit/pull/474), [#475](https://github.com/nims-mdpf/rdetoolkit/pull/475)
+
+#### Highlights
+- Fixed SmartTable new sample registration setting `sampleId` to empty string instead of `None`, which caused a server-side "non-existent sample ID" error
+- Fixed uppercase image file extensions (`.JPG`, `.JPEG`, `.PNG`) not being copied to the thumbnail folder on case-sensitive file systems
+
+### Bug Fixes
+
+#### SmartTable New Sample Registration sampleId Fix (Issue #470)
+
+**Problem**: When registering a new sample via SmartTable, `_clear_sample_for_new_registration()` set `sampleId` to an empty string `""`. The server interpreted this as a reference to a non-existent sample, resulting in the error "存在しない試料IDが指定されました" (non-existent sample ID specified).
+
+**Changes**:
+
+- Changed `_clear_sample_for_new_registration()` to set `sampleId = None` instead of `sampleId = ""` in `src/rdetoolkit/processing/processors/invoice.py`
+- Updated docstring to clarify that `None` indicates new sample registration and empty string causes server-side error
+- Updated existing test assertions from `== ""` to `is None`
+- Added regression test `test_new_sample_sampleid_is_none_not_empty_string__issue_470`
+
+#### Support Uppercase Image Extensions in Thumbnail Copy (Issue #473)
+
+**Problem**: Image files with uppercase extensions (`.JPG`, `.JPEG`, `.PNG`) were not copied to the `data/thumbnail` folder. Python's `glob.glob()` depends on the OS file system's case-sensitivity. On Linux (ext4) and Docker containers (case-sensitive), uppercase extensions did not match the lowercase-only extension list. macOS (APFS, case-insensitive by default) did not exhibit this issue, making it harder to detect during development.
+
+**Changes**:
+
+- Added uppercase extension variants (`.JPG`, `.JPEG`, `.PNG`, `.GIF`, `.BMP`, `.SVG`, `.WEBP`) to the image extension list in `copy_images_to_thumbnail` function (`src/rdetoolkit/img2thumb.py`)
+- Added `.tif`/`.tiff` and their uppercase variants (`.TIF`, `.TIFF`) which were previously missing from the extension list
+- Refactored to use single directory scan with case-insensitive extension matching for improved efficiency
+- Added 4 test cases in `tests/test_thumbnail.py` to verify uppercase extension handling
+- Fixed an unrelated mypy type error in `src/rdetoolkit/graph/renderers/plotly_renderer.py`
+
+### Testing
+
+- `tests/processing/processors/test_invoice_smarttable.py`: Updated assertions and added regression test for Issue #470
+- `tests/test_smarttable_invoice_initializer.py`: Updated assertions from `== ""` to `is None`
+- `tests/test_thumbnail.py`: Added 4 new test cases for uppercase extension handling
+
+### Migration / Compatibility
+
+- If your workflow relies on `sampleId` being an empty string `""` after `_clear_sample_for_new_registration()`, it is now `None`. This is the correct behavior for new sample registration on the RDE server
+- Thumbnail copy now supports uppercase image extensions (`.JPG`, `.JPEG`, `.PNG`, etc.) and `.tif`/`.tiff` formats, which were previously ignored on case-sensitive file systems. No user action required
+
+---
 
 ## v1.6.2 (2026-03-16)
 

--- a/docs/releases/index.ja.md
+++ b/docs/releases/index.ja.md
@@ -53,8 +53,8 @@
 
 **修正内容**:
 
-- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で画像拡張子リストに大文字バリアント（`.JPG`、`.JPEG`、`.PNG`、`.GIF`、`.BMP`、`.SVG`、`.WEBP`）を追加
-- これまで拡張子リストに含まれていなかった`.tif`/`.tiff`とその大文字バリアント（`.TIF`、`.TIFF`）を追加
+- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で、`path.suffix.lower()`によるcase-insensitiveな拡張子判定に変更
+- これまで対応対象に含まれていなかった`.tif`/`.tiff`を追加し、これらもcase-insensitiveに判定されるよう修正
 - 単一ディレクトリスキャンによるcase-insensitive拡張子マッチングにリファクタリングし、効率を改善
 - `tests/test_thumbnail.py`に大文字拡張子処理を検証するテストケース4件を追加
 - `src/rdetoolkit/graph/renderers/plotly_renderer.py`の既存mypy型エラーを修正（Issue外）

--- a/docs/releases/index.ja.md
+++ b/docs/releases/index.ja.md
@@ -4,6 +4,7 @@
 
 | バージョン | リリース日 | 主な変更点 | 詳細セクション |
 | ---------- | ---------- | ---------- | -------------- |
+| v1.6.3     | 2026-04-13 | SmartTable新規試料登録時の`sampleId`を空文字ではなく`None`に修正 / サムネイルコピーで大文字画像拡張子をサポート | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2     | 2026-03-16 | SmartTableで`sample/names`指定時にダミー試料の`sampleId`が黙って継承される問題を修正 / SmartTableのファイル参照がzip内に存在しない場合のエラーメッセージ改善 | [v1.6.2](#v162-2026-03-16) |
 | v1.6.1     | 2026-03-10 | chardet公開API移行（Python 3.14互換） / SmartTableカスタムフィールドの型キャスト修正 | [v1.6.1](#v161-2026-03-10) |
 | v1.6.0     | 2026-02-18 | **破壊的変更**: Python 3.9サポート終了（最小バージョン3.10+） / `pytz`の直接依存を削除 / `gen-invoice`コマンド追加 / AIエージェントガイド埋め込み / Agent Skills追加 | [v1.6.0](#v160-2026-02-18) |
@@ -22,6 +23,54 @@
 | v1.2.0     | 2025-04-14 | MinIO対応 / アーカイブ生成 / レポート生成 | [v1.2.0](#v120-2025-04-14) |
 
 # リリース詳細
+
+## v1.6.3 (2026-04-13)
+
+!!! info "参照"
+    - 主な課題: [#470](https://github.com/nims-mdpf/rdetoolkit/issues/470), [#473](https://github.com/nims-mdpf/rdetoolkit/issues/473)
+    - プルリクエスト: [#474](https://github.com/nims-mdpf/rdetoolkit/pull/474), [#475](https://github.com/nims-mdpf/rdetoolkit/pull/475)
+
+#### ハイライト
+- SmartTableで新規試料を登録する際に`sampleId`が空文字`""`に設定され、サーバー側で「存在しない試料IDが指定されました」エラーが発生する問題を修正
+- 大文字拡張子の画像ファイル（`.JPG`、`.JPEG`、`.PNG`）がcase-sensitiveなファイルシステム上でサムネイルフォルダにコピーされない問題を修正
+
+### バグ修正
+
+#### SmartTable新規試料登録時のsampleId修正 (Issue #470)
+
+**問題**: SmartTableで新規試料を登録する際、`_clear_sample_for_new_registration()`が`sampleId`を空文字`""`に設定していました。サーバーはこれを存在しない試料IDへの参照と解釈し、「存在しない試料IDが指定されました」というエラーが発生していました。
+
+**修正内容**:
+
+- `src/rdetoolkit/processing/processors/invoice.py`の`_clear_sample_for_new_registration()`で`sampleId`を`""`ではなく`None`に設定するよう変更
+- `None`が新規試料登録を意味し、空文字がサーバーエラーを引き起こすことをdocstringに明記
+- 既存テストのアサーションを`== ""`から`is None`に修正
+- 回帰テスト`test_new_sample_sampleid_is_none_not_empty_string__issue_470`を追加
+
+#### サムネイルコピーでの大文字画像拡張子サポート (Issue #473)
+
+**問題**: 大文字拡張子の画像ファイル（`.JPG`、`.JPEG`、`.PNG`）が`data/thumbnail`フォルダにコピーされていませんでした。Pythonの`glob.glob()`はOSのファイルシステムのcase-sensitivityに依存しており、Linux（ext4）やDockerコンテナ（case-sensitive）では小文字のみの拡張子リストに大文字拡張子がマッチしませんでした。macOS（APFS、デフォルトでcase-insensitive）では問題が発現しないため、開発時に検出が困難でした。
+
+**修正内容**:
+
+- `src/rdetoolkit/img2thumb.py`の`copy_images_to_thumbnail`関数で画像拡張子リストに大文字バリアント（`.JPG`、`.JPEG`、`.PNG`、`.GIF`、`.BMP`、`.SVG`、`.WEBP`）を追加
+- これまで拡張子リストに含まれていなかった`.tif`/`.tiff`とその大文字バリアント（`.TIF`、`.TIFF`）を追加
+- 単一ディレクトリスキャンによるcase-insensitive拡張子マッチングにリファクタリングし、効率を改善
+- `tests/test_thumbnail.py`に大文字拡張子処理を検証するテストケース4件を追加
+- `src/rdetoolkit/graph/renderers/plotly_renderer.py`の既存mypy型エラーを修正（Issue外）
+
+### テスト
+
+- `tests/processing/processors/test_invoice_smarttable.py`: アサーション更新およびIssue #470の回帰テストを追加
+- `tests/test_smarttable_invoice_initializer.py`: アサーションを`== ""`から`is None`に更新
+- `tests/test_thumbnail.py`: 大文字拡張子処理のテストケース4件を追加
+
+### 移行 / 互換性
+
+- `_clear_sample_for_new_registration()`後の`sampleId`が空文字`""`から`None`に変更されます。これはRDEサーバーでの新規試料登録に必要な正しい動作です
+- サムネイルコピーが大文字画像拡張子（`.JPG`、`.JPEG`、`.PNG`等）と`.tif`/`.tiff`形式をサポートするようになりました。case-sensitiveなファイルシステムで以前無視されていたファイルもコピーされます。ユーザーの対応は不要です
+
+---
 
 ## v1.6.2 (2026-03-16)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rdetoolkit"
-version = "1.6.2"
+version = "1.6.3"
 description = "A module that supports the workflow of the RDE dataset construction program"
 authors = [{ name = "NIMS MDPF", email = "rde@nims.go" }]
 keywords = ["rdetoolkit", "RDE", "toolkit", "structure", "dataset"]

--- a/src/rdetoolkit/__init__.py
+++ b/src/rdetoolkit/__init__.py
@@ -14,7 +14,7 @@ if sys.version_info < (3, 10):  # noqa: UP036
 from importlib import import_module
 from typing import Any
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "DirectoryOps": ("rdetoolkit.core", "DirectoryOps"),

--- a/src/rdetoolkit/graph/renderers/plotly_renderer.py
+++ b/src/rdetoolkit/graph/renderers/plotly_renderer.py
@@ -122,7 +122,7 @@ class PlotlyRenderer:
             msg = f"x_cols ({len(x_cols)}) and y_cols ({len(y_cols)}) must match"
             raise ValueError(msg)
 
-        direction_cols = (
+        direction_cols: list[int | str | None] = (
             list(config.direction_cols)
             if config.direction_cols
             else [None] * len(y_cols)

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -53,11 +53,9 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
+    default_img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"]
     img_exts = (
-        [
-            ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff",
-            ".JPG", ".JPEG", ".PNG", ".GIF", ".BMP", ".SVG", ".WEBP", ".TIF", ".TIFF",
-        ]
+        default_img_exts + [ext.upper() for ext in default_img_exts]
         if img_ext is None
         else [img_ext]
     )

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -53,9 +53,15 @@ def copy_images_to_thumbnail(
         img_ext (str, optional): image file extension.
     """
     default_img_exts = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"}
-    normalized_img_exts = default_img_exts if img_ext is None else {img_ext.lower()}
+    normalized_img_exts = (
+        default_img_exts
+        if img_ext is None
+        else {img_ext.lower() if img_ext.startswith(".") else f".{img_ext.lower()}"}
+    )
 
     main_img_dir = Path(out_dir_main_img)
+    if not main_img_dir.is_dir():
+        return
     img_path_main = [
         str(path)
         for path in sorted(main_img_dir.iterdir())

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -53,7 +53,14 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
-    img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp"] if img_ext is None else [img_ext]
+    img_exts = (
+        [
+            ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff",
+            ".JPG", ".JPEG", ".PNG", ".GIF", ".BMP", ".SVG", ".WEBP", ".TIF", ".TIFF",
+        ]
+        if img_ext is None
+        else [img_ext]
+    )
 
     img_paths_main = [glob(os.path.join(out_dir_main_img, "*" + ext)) for ext in img_exts]
     img_path_main = list(itertools.chain.from_iterable(img_paths_main))

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import os
 import shutil
 from glob import glob
@@ -53,15 +52,15 @@ def copy_images_to_thumbnail(
         target_image_name (str, optional): Specify the name of the image file to be copied to the thumbnail folder.
         img_ext (str, optional): image file extension.
     """
-    default_img_exts = [".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"]
-    img_exts = (
-        default_img_exts + [ext.upper() for ext in default_img_exts]
-        if img_ext is None
-        else [img_ext]
-    )
+    default_img_exts = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp", ".tif", ".tiff"}
+    normalized_img_exts = default_img_exts if img_ext is None else {img_ext.lower()}
 
-    img_paths_main = [glob(os.path.join(out_dir_main_img, "*" + ext)) for ext in img_exts]
-    img_path_main = list(itertools.chain.from_iterable(img_paths_main))
+    main_img_dir = Path(out_dir_main_img)
+    img_path_main = [
+        str(path)
+        for path in sorted(main_img_dir.iterdir())
+        if path.is_file() and path.suffix.lower() in normalized_img_exts
+    ]
 
     # When there are multiple images in the main image folder, copy one at the leading index as the representative image.
     __main_img_path: str = ""

--- a/src/rdetoolkit/processing/processors/invoice.py
+++ b/src/rdetoolkit/processing/processors/invoice.py
@@ -659,7 +659,7 @@ class SmartTableInvoiceInitializer(Processor):
 
         Fields cleared:
 
-        - ``sample.sampleId`` → ``""`` (empty string indicates a new sample)
+        - ``sample.sampleId`` → ``None`` (None indicates new sample registration; empty string causes server-side error)
         - ``sample.description`` → ``None``
         - ``sample.composition`` → ``None``
         - ``sample.referenceUrl`` → ``None``
@@ -672,7 +672,7 @@ class SmartTableInvoiceInitializer(Processor):
         """
         sample_section = invoice_data.setdefault("sample", {})
 
-        sample_section["sampleId"] = ""
+        sample_section["sampleId"] = None
         for field in ("description", "composition", "referenceUrl"):
             sample_section[field] = None
 

--- a/tests/processing/processors/test_invoice_smarttable.py
+++ b/tests/processing/processors/test_invoice_smarttable.py
@@ -493,7 +493,7 @@ class TestSmartTableInvoiceInitializerIntegration:
         with open(context.invoice_dst_filepath) as f:
             output = json.load(f)
 
-        assert output["sample"]["sampleId"] == ""
+        assert output["sample"]["sampleId"] is None
         assert output["sample"]["description"] is None
         assert output["sample"]["composition"] is None
         assert output["sample"]["referenceUrl"] is None
@@ -574,8 +574,46 @@ class TestSmartTableInvoiceInitializerIntegration:
             output = json.load(f)
 
         # Then: sampleId is cleared (new-sample) AND ownerId = basic.dataOwnerId (#389)
-        assert output["sample"]["sampleId"] == ""
+        assert output["sample"]["sampleId"] is None
         assert output["sample"]["ownerId"] == expected_owner_id
+
+    def test_new_sample_sampleid_is_none_not_empty_string__issue_470(self, smarttable_processing_context):
+        """Issue #470: sample/names given without sample/sampleId must set sampleId to None, not empty string.
+
+        An empty-string sampleId causes a server-side error
+        ("存在しない試料IDが指定されました").
+        None correctly indicates new sample registration intent.
+        """
+        # Given: original invoice has a dummy sampleId and filled dummy fields
+        processor = SmartTableInvoiceInitializer()
+        context = smarttable_processing_context
+        SmartTableInvoiceInitializer._BASE_INVOICE_CACHE.clear()
+        self._setup_invoice_with_dummy_sample(context)
+
+        # CSV has sample/names but no sample/sampleId column (new sample registration intent)
+        csv_data = pd.DataFrame({
+            "sample/names": ["Brand New Sample"],
+            "basic/dataName": ["Issue470 Data"],
+        })
+        csv_path = context.smarttable_rowfile
+        assert csv_path is not None
+        csv_data.to_csv(csv_path, index=False)
+
+        # When: processing (new sample registration: names present, sampleId absent)
+        processor.process(context)
+
+        # Then: sampleId must be None (not empty string "")
+        with open(context.invoice_dst_filepath) as f:
+            output = json.load(f)
+
+        assert output["sample"]["sampleId"] is None, (
+            "sampleId should be None for new sample registration, not empty string. "
+            "Empty string causes server-side error: '存在しない試料IDが指定されました'"
+        )
+        assert output["sample"]["sampleId"] != "", (
+            "sampleId must not be empty string; this causes the RDE server error in Issue #470"
+        )
+        assert output["sample"]["names"] == ["Brand New Sample"]
 
 
 class TestSmartTableEarlyExitProcessorIntegration:

--- a/tests/test_smarttable_invoice_initializer.py
+++ b/tests/test_smarttable_invoice_initializer.py
@@ -1,31 +1,33 @@
 """Test SmartTableInvoiceInitializer behavior with equivalence partitioning and boundary values.
 
 Equivalence Partitioning:
-| API                                   | Input/State Partition                                         | Rationale                                                              | Expected Outcome                                                      | Test ID       |
-| ------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------- |
-| `SmartTableInvoiceInitializer.process` | Multiple SmartTable rows with fresh processors per row        | Pipelines re-instantiate processors for each row                       | sample.ownerId is set to basic.dataOwnerId                            | `TC-EP-001`   |
-| `SmartTableInvoiceInitializer.process` | Missing SmartTable row CSV in SmartTable mode                  | Invalid SmartTable input should be rejected                             | Raises `StructuredError`                                              | `TC-EP-002`   |
-| `SmartTableInvoiceInitializer.process` | basic.dataOwnerId is missing in original invoice               | Defensive handling when required field is absent                       | Logs warning, preserves original sample.ownerId                       | `TC-EP-003`   |
-| `SmartTableInvoiceInitializer.process` | SmartTable CSV contains sample/ownerId column                  | CSV value should take precedence when explicitly specified             | sample.ownerId uses CSV value, not basic.dataOwnerId                  | `TC-EP-004`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId column absent          | New sample registration; dummy sampleId must not be inherited          | sampleId→"", description/composition/referenceUrl→None, attr values→None | `TC-EP-005`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId = UUID                 | Explicit reference to existing sample; no clearing should occur        | sampleId preserved, other fields unchanged                            | `TC-EP-006`   |
-| `SmartTableInvoiceInitializer.process` | Neither sample/names nor sample/sampleId specified             | No sample intent; original invoice sample fields must be preserved     | All original sample fields unchanged                                  | `TC-EP-007`   |
-| `SmartTableInvoiceInitializer.process` | sample/names specified, sample/sampleId column present but ""  | Explicit empty sampleId treated same as absent; new sample             | sampleId→"", other fields cleared                                     | `TC-EP-008`   |
-| `SmartTableInvoiceInitializer.process` | sample/names only; Issue #389 ownerId correction still applies | Clearing must not break existing ownerId auto-assignment logic         | sample.ownerId = basic.dataOwnerId after clearing                     | `TC-EP-009`   |
-| `SmartTableInvoiceInitializer.process` | sample/names with fixed-header blank sample columns            | New sample clearing must survive the generic blank-cell clearing pass  | sampleId/description and attribute structures remain cleared, not removed | `TC-EP-010` |
-| `SmartTableInvoiceInitializer.process` | sample/names + UUID + blank sample field                       | Existing sample reference path must keep generic blank-cell clearing   | Explicit sampleId kept; blank sample field is removed                 | `TC-EP-011`   |
-| `SmartTableInvoiceInitializer.process` | Original invoice has `sample.generalAttributes = null`         | SmartTable must normalize null containers before term assignment       | `sample/generalAttributes.<termId>` is written without error          | `TC-EP-012`   |
-| `SmartTableInvoiceInitializer.process` | Original invoice has `sample.specificAttributes = null`        | SmartTable must normalize null containers before class/term assignment | `sample/specificAttributes.<classId>.<termId>` is written without error | `TC-EP-013` |
+
+| Input/State Partition                                   | Expected Outcome                                       | Test ID     |
+| ------------------------------------------------------- | ------------------------------------------------------ | ----------- |
+| Multiple SmartTable rows with fresh processors per row  | sample.ownerId is set to basic.dataOwnerId             | TC-EP-001   |
+| Missing SmartTable row CSV in SmartTable mode           | Raises StructuredError                                 | TC-EP-002   |
+| basic.dataOwnerId is missing in original invoice        | Logs warning, preserves original sample.ownerId        | TC-EP-003   |
+| SmartTable CSV contains sample/ownerId column           | sample.ownerId uses CSV value, not basic.dataOwnerId   | TC-EP-004   |
+| sample/names specified, sample/sampleId absent          | sampleId=None, other dummy fields cleared              | TC-EP-005   |
+| sample/names specified, sample/sampleId = UUID          | sampleId preserved, other fields unchanged             | TC-EP-006   |
+| Neither sample/names nor sample/sampleId specified      | All original sample fields unchanged                   | TC-EP-007   |
+| sample/names given, sample/sampleId column present=""  | sampleId=None, other fields cleared                    | TC-EP-008   |
+| sample/names only; Issue #389 ownerId correction        | sample.ownerId = basic.dataOwnerId after clearing      | TC-EP-009   |
+| sample/names with fixed-header blank sample columns     | Cleared structures remain, not removed                 | TC-EP-010   |
+| sample/names + UUID + blank sample field                | Explicit sampleId kept; blank field removed            | TC-EP-011   |
+| Original invoice has sample.generalAttributes = null   | generalAttributes.<termId> written without error       | TC-EP-012   |
+| Original invoice has sample.specificAttributes = null  | specificAttributes.<classId>.<termId> written ok       | TC-EP-013   |
 
 Boundary Value:
-| API                                   | Boundary                                       | Rationale                                               | Expected Outcome                            | Test ID       |
-| ------------------------------------- | ---------------------------------------------- | ------------------------------------------------------- | ------------------------------------------- | ------------- |
-| `SmartTableInvoiceInitializer.process` | First invocation with SmartTable row           | Automatic ownerId assignment from basic.dataOwnerId     | sample.ownerId is set to basic.dataOwnerId  | `TC-BV-001`   |
-| `SmartTableInvoiceInitializer.process` | `smarttable_file` is `None`                     | SmartTable mode should be enforced                      | Raises `ValueError`                         | `TC-BV-002`   |
-| `SmartTableInvoiceInitializer.process` | basic.dataOwnerId is empty string               | Defensive handling when field is empty                  | Logs warning, preserves original ownerId    | `TC-BV-003`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: empty string ""       | Empty string is not a valid sampleId reference          | Treated as absent; new sample clearing runs | `TC-BV-004`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: valid UUID string     | UUID present means explicit reference to existing sample| No clearing; sampleId preserved             | `TC-BV-005`   |
-| `SmartTableInvoiceInitializer.process` | sample/sampleId boundary: whitespace-only "   " | Whitespace-only must not be treated as valid sampleId   | Treated as absent; new sample clearing runs | `TC-BV-006`   |
+
+| Boundary                                     | Expected Outcome                            | Test ID   |
+| -------------------------------------------- | ------------------------------------------- | --------- |
+| First invocation with SmartTable row         | sample.ownerId set to basic.dataOwnerId     | TC-BV-001 |
+| smarttable_file is None                      | Raises ValueError                           | TC-BV-002 |
+| basic.dataOwnerId is empty string            | Logs warning, preserves original ownerId    | TC-BV-003 |
+| sample/sampleId = empty string ""            | Treated as absent; new sample clearing runs | TC-BV-004 |
+| sample/sampleId = valid UUID string          | No clearing; sampleId preserved             | TC-BV-005 |
+| sample/sampleId = whitespace-only "   "      | Treated as absent; new sample clearing runs | TC-BV-006 |
 """
 
 from __future__ import annotations
@@ -510,7 +512,7 @@ def test_smarttable_clears_dummy_sample_when_names_only__tc_ep_005(tmp_path: Pat
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: dummy sampleId is cleared
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     # Then: dummy text fields are cleared
     assert output["sample"]["description"] is None
     assert output["sample"]["composition"] is None
@@ -578,7 +580,7 @@ def test_smarttable_clears_dummy_sample_when_sampleid_empty__tc_ep_008(tmp_path:
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: new-sample clearing applies because sampleId was not a non-empty value
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     assert output["sample"]["names"] == ["Brand New"]
 
@@ -596,7 +598,7 @@ def test_smarttable_ownerid_corrected_after_new_sample_clearing__tc_ep_009(tmp_p
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: sampleId is cleared (new-sample clearing ran)
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     # Then: ownerId is set to basic.dataOwnerId (Issue #389 logic preserved)
     assert output["sample"]["ownerId"] == expected_owner_id
 
@@ -627,7 +629,7 @@ def test_smarttable_preserves_cleared_sample_fields_for_blank_fixed_headers__tc_
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: cleared scalar fields remain in their normalized empty form
-    assert output["sample"]["sampleId"] == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     # Then: cleared attribute entries are preserved instead of being deleted
     assert any(
@@ -733,7 +735,7 @@ def test_smarttable_empty_sampleid_boundary_triggers_clearing__tc_bv_004(tmp_pat
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: empty sampleId in CSV is treated as "no sampleId" → clearing applies
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
 
 
@@ -777,6 +779,6 @@ def test_smarttable_whitespace_sampleid_triggers_clearing__tc_bv_006(tmp_path: P
     output = json.loads((invoice_org.parent / "invoice.json").read_text())
 
     # Then: whitespace-only sampleId is equivalent to absent → new-sample clearing applies
-    assert output["sample"].get("sampleId", "") == ""
+    assert output["sample"]["sampleId"] is None
     assert output["sample"]["description"] is None
     assert output["sample"]["names"] == ["Brand New BV-006"]

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -155,25 +155,25 @@ def test_resize_image_exception_handling():
 
 @pytest.mark.parametrize("filename", ["dummy_main_img.JPG", "dummy_main_img.JPEG", "dummy_main_img.PNG"])
 def test_copy_images_to_thumbnail_uppercase_extensions(dummy_out_dir_thumb, dummy_out_dir_main, filename):
-    """大文字拡張子のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: 大文字拡張子のダミー画像ファイルをmain_imageに配置
+    """Test that files with uppercase extensions are copied to the thumbnail folder."""
+    # Given: a dummy image file with an uppercase extension in main_image
     with open(dummy_out_dir_main.joinpath(filename), "w") as f:
         f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
+    # When: copy_images_to_thumbnail is called
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    # Then: exactly one file should be copied to the thumbnail folder
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
     assert dummy_out_dir_thumb.joinpath(filename).exists()
 
 
 def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):
-    """小文字・大文字拡張子が混在する場合に代表画像が1つコピーされることを確認するテスト"""
-    # Given: 小文字・大文字混在のダミー画像ファイルをmain_imageに配置
+    """Test that only one representative image is copied when mixed-case extensions exist."""
+    # Given: dummy image files with both lowercase and uppercase extensions in main_image
     with open(dummy_out_dir_main.joinpath("dummy_main_img_lower.jpg"), "w") as f:
         f.write("dummy")
     with open(dummy_out_dir_main.joinpath("dummy_main_img_upper.JPG"), "w") as f:
         f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
+    # When: copy_images_to_thumbnail is called
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルのみがコピーされていること（代表画像は1つ）
+    # Then: only one representative image should be copied to the thumbnail folder
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -153,40 +153,17 @@ def test_resize_image_exception_handling():
             resize_image(image_path, width, height, output_path)
 
 
-def test_copy_images_to_thumbnail_uppercase_jpg(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .JPG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .JPG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPG"), "w") as f:
+@pytest.mark.parametrize("filename", ["dummy_main_img.JPG", "dummy_main_img.JPEG", "dummy_main_img.PNG"])
+def test_copy_images_to_thumbnail_uppercase_extensions(dummy_out_dir_thumb, dummy_out_dir_main, filename):
+    """大文字拡張子のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: 大文字拡張子のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath(filename), "w") as f:
         f.write("dummy")
     # When: copy_images_to_thumbnailを実行
     copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
     # Then: サムネイルフォルダに1つのファイルがコピーされていること
     assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPG").exists()
-
-
-def test_copy_images_to_thumbnail_uppercase_jpeg(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .JPEG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .JPEG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPEG"), "w") as f:
-        f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
-    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
-    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPEG").exists()
-
-
-def test_copy_images_to_thumbnail_uppercase_png(dummy_out_dir_thumb, dummy_out_dir_main):
-    """大文字拡張子 .PNG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
-    # Given: .PNG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
-    with open(dummy_out_dir_main.joinpath("dummy_main_img.PNG"), "w") as f:
-        f.write("dummy")
-    # When: copy_images_to_thumbnailを実行
-    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
-    # Then: サムネイルフォルダに1つのファイルがコピーされていること
-    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
-    assert dummy_out_dir_thumb.joinpath("dummy_main_img.PNG").exists()
+    assert dummy_out_dir_thumb.joinpath(filename).exists()
 
 
 def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):

--- a/tests/test_thumbnail.py
+++ b/tests/test_thumbnail.py
@@ -151,3 +151,52 @@ def test_resize_image_exception_handling():
 
         with pytest.raises(StructuredError, match="Failed to resize image: Mocked exception"):
             resize_image(image_path, width, height, output_path)
+
+
+def test_copy_images_to_thumbnail_uppercase_jpg(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .JPG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .JPG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPG").exists()
+
+
+def test_copy_images_to_thumbnail_uppercase_jpeg(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .JPEG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .JPEG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.JPEG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.JPEG").exists()
+
+
+def test_copy_images_to_thumbnail_uppercase_png(dummy_out_dir_thumb, dummy_out_dir_main):
+    """大文字拡張子 .PNG のファイルがサムネイルフォルダにコピーされることを確認するテスト"""
+    # Given: .PNG拡張子（大文字）のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img.PNG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルがコピーされていること
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1
+    assert dummy_out_dir_thumb.joinpath("dummy_main_img.PNG").exists()
+
+
+def test_copy_images_to_thumbnail_mixed_case_extensions(dummy_out_dir_thumb, dummy_out_dir_main):
+    """小文字・大文字拡張子が混在する場合に代表画像が1つコピーされることを確認するテスト"""
+    # Given: 小文字・大文字混在のダミー画像ファイルをmain_imageに配置
+    with open(dummy_out_dir_main.joinpath("dummy_main_img_lower.jpg"), "w") as f:
+        f.write("dummy")
+    with open(dummy_out_dir_main.joinpath("dummy_main_img_upper.JPG"), "w") as f:
+        f.write("dummy")
+    # When: copy_images_to_thumbnailを実行
+    copy_images_to_thumbnail(dummy_out_dir_thumb, dummy_out_dir_main)
+    # Then: サムネイルフォルダに1つのファイルのみがコピーされていること（代表画像は1つ）
+    assert len(list(dummy_out_dir_thumb.glob("*"))) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1357,7 +1357,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs"
-version = "1.6.2"
+version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1374,9 +1374,9 @@ dependencies = [
     { name = "pyyaml-env-tag" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.2.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.3.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.2-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.3-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
 ]
 
 [[package]]
@@ -1990,11 +1990,11 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.6.2"
+version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.2.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.3.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.2-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.3-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ wheels = [
 
 [[package]]
 name = "rdetoolkit"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "build" },
@@ -2658,7 +2658,7 @@ dev = [
     { name = "lizard", specifier = ">=1.17.10" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "minio", specifier = ">=7.2.15" },
-    { name = "mkdocs", specifier = ">=1.6.2" },
+    { name = "mkdocs", specifier = ">=1.6.3" },
     { name = "mkdocs-material", specifier = ">=9.5.1" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.1" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1357,7 +1357,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs"
-version = "1.6.3"
+version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1374,9 +1374,9 @@ dependencies = [
     { name = "pyyaml-env-tag" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.3.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.3-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
 ]
 
 [[package]]
@@ -1990,11 +1990,11 @@ wheels = [
 
 [[package]]
 name = "pluggy"
-version = "1.6.3"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.3.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.3-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -2658,7 +2658,7 @@ dev = [
     { name = "lizard", specifier = ">=1.17.10" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "minio", specifier = ">=7.2.15" },
-    { name = "mkdocs", specifier = ">=1.6.3" },
+    { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.5.1" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.1.1" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },


### PR DESCRIPTION
### **User description**
## Summary
- **fix**: Set sampleId to None instead of empty string for new sample registration in SmartTable mode (#470)
- **fix**: Support uppercase image extensions (.JPG, .PNG, etc.) in thumbnail copy (#473)
- **refactor**: Consolidate image extension matching into a single directory scan with case-insensitive matching
- **docs**: Add v1.6.3 CHANGELOG (Japanese & English)

## Changes
- `processing/processors/invoice.py`: Change sampleId initial value from `""` to `None`
- `img2thumb.py`: Refactor to case-insensitive extension matching
- Add test cases for SmartTable sampleId and uppercase extension thumbnails
- Version bump 1.6.2 → 1.6.3

## Test plan
- [x] Added test for sampleId=None on new sample registration in SmartTable mode
- [x] Added test for thumbnail copy with uppercase extensions (.JPG, etc.)
- [x] Verified no regression in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Documentation, Enhancement


___

### **Description**
- Fix SmartTable new sample registration: set `sampleId` to None, not empty string
  - Prevents server error "存在しない試料IDが指定されました"
  - Updates docstrings and all related test assertions
  - Adds regression test for this scenario

- Support uppercase image extensions in thumbnail copy
  - Adds `.JPG`, `.JPEG`, `.PNG`, `.TIF`, `.TIFF` (case-insensitive) support
  - Refactors to single directory scan for efficiency and correctness
  - Adds new tests for uppercase/mixed-case extension handling

- Update documentation and changelogs for v1.6.3 release
  - Details bug fixes and migration notes in English and Japanese

- Bump version to 1.6.3 in code and pyproject.toml


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SmartTable new sample registration"] -- "sampleId set to None (not '')" --> B["No server error on registration"]
  C["Thumbnail copy function"] -- "Case-insensitive extension scan" --> D["Uppercase images copied"]
  E["Tests"] -- "Update & add for new behaviors" --> F["Regression & extension tests"]
  G["Docs & version"] -- "Release notes, version bump" --> H["v1.6.3 published"]
  A -- "Docstring & test assertion updates" --> E
  C -- "Refactor & extension support" --> D
  D -- "Tested by" --> F
  B -- "Tested by" --> F
  F -- "Documented in" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>invoice.py</strong><dd><code>Set sampleId to None for new SmartTable samples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-2bad8b90d4f46b258fc1d0835a5b4a88ac12e041809e82712f0450b5bb663676">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plotly_renderer.py</strong><dd><code>Fix mypy type error in direction_cols assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-c54a83b998bffef2022b93312223197f8756299623c2e9f6463d456512e8e750">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_invoice_smarttable.py</strong><dd><code>Update and add tests for sampleId=None on new registration</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-15640c71a36f52ec9f869387a3dd9cfa2a25e13cd02fcd72adba837e0b41d171">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_smarttable_invoice_initializer.py</strong><dd><code>Update assertions for sampleId=None and related test logic</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-91a77f650ffa7f8de530c49e70db76a8af0ea949ab179da8ecfe2764aa4b6ce4">+31/-29</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_thumbnail.py</strong><dd><code>Add tests for uppercase/mixed-case image extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-966fdabd28c9ebfa4499d0c6ed3bceb40412946ff5ccd712ac105577bbb44d20">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>img2thumb.py</strong><dd><code>Refactor thumbnail copy for case-insensitive extension support</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-b667b0b9af1955791b92db59863ca8b842f8345714d5caaa45f1e7317ef61885">+15/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Bump version to 1.6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-b2b5edda308439d777cf4d737fac773062cf78befc70bfb9f5ebc4917296094f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Update project version to 1.6.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add v1.6.3 release notes with bug fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.en.md</strong><dd><code>Document v1.6.3 release and bug fixes (EN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-4927398bbc5416d2373f7d5ab4f4dbc448bd1d02438f0017b365b025d50e3095">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ja.md</strong><dd><code>Document v1.6.3 release and bug fixes (JA)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/478/files#diff-918a15bad39655ff5c737a14fdb798f5f9befb7357cdf4d61bab286a791e64bc">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

