### PR TITLE
Fix SmartTable data registration order to follow table row order

### DIFF
--- a/src/rdetoolkit/impl/input_controller.py
+++ b/src/rdetoolkit/impl/input_controller.py
@@ -391,6 +391,9 @@ class SmartTableChecker(IInputFileChecker):
 
     This class handles SmartTable files (Excel/CSV/TSV) and optionally zip files,
     processing them for metadata extraction and invoice generation.
+    The returned ``raw_files`` order is tied to RDE registration order:
+    index 0 maps to ``data/`` and is registered last, while index 1..N map to
+    ``data/divided/0001``.. and are registered first in ascending index order.
 
     Attributes:
         out_dir_temp (Path): Temporary directory for the unpacked content.

--- a/src/rdetoolkit/impl/input_controller.py
+++ b/src/rdetoolkit/impl/input_controller.py
@@ -460,15 +460,25 @@ class SmartTableChecker(IInputFileChecker):
         )
 
         # Convert to RawFiles format: each mapping becomes a tuple
+        # (data rows preserve table order: row1, row2, ..., rowN)
+        data_rows: list[tuple[Path, ...]] = [
+            (csv_path,) + related_files for csv_path, related_files in csv_file_mappings
+        ]
+
+        # The RDE system registers data/divided/0001..N first and data/ root (idx=0) LAST.
+        # raw_files index mapping: idx=0 -> data/ root, idx>=1 -> data/divided/000{idx}.
         raw_files: list[tuple[Path, ...]] = []
-
-        # First entry: SmartTable file only (if save_table_file is True)
         if self.save_table_file:
+            # SmartTable file occupies data/ root (registers last);
+            # data rows fill divided/0001+ so registration order stays row1..rowN.
             raw_files.append((smarttable_file,))
-
-        # Subsequent entries: Each CSV file with its related files
-        for csv_path, related_files in csv_file_mappings:
-            raw_files.append((csv_path,) + related_files)
+            raw_files.extend(data_rows)
+        elif data_rows:
+            # No SmartTable file, but data/ root must always be registered (and registers
+            # last). Place the LAST data row at idx=0 so the registration order stays
+            # row1..rowN, with earlier rows filling divided/0001+.
+            raw_files.append(data_rows[-1])
+            raw_files.extend(data_rows[:-1])
 
         return raw_files, smarttable_file
 

--- a/tests/test_smarttable_checker.py
+++ b/tests/test_smarttable_checker.py
@@ -1,4 +1,20 @@
-"""Test SmartTableChecker functionality."""
+"""Test SmartTableChecker functionality.
+
+Equivalence Partitioning:
+| API | Input/State Partition | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| ``SmartTableChecker.parse`` + ``generate_folder_paths_iterator`` | SmartTable mode with saved table file | valid domain | table file is in data/ root and row CSVs populate divided folders | TC-EP-SMARTTABLE-ITER-001 |
+| ``SmartTableChecker.parse`` + ``generate_folder_paths_iterator`` | SmartTable mode without saved table file | valid domain | last row is in data/ root and earlier row CSVs populate divided folders | TC-EP-SMARTTABLE-ITER-002 |
+
+Boundary Value:
+| API | Boundary | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| ``SmartTableChecker.parse`` + ``generate_folder_paths_iterator`` | two generated data rows | minimum row count that exercises root/divided reordering | rowfile mapping follows RDE registration order | TC-BV-SMARTTABLE-ITER-001 |
+
+Validation commands:
+Direct: ``uv run pytest tests/test_smarttable_checker.py tests/test_generate_folder_paths_iterator.py -q``
+Tox: ``tox -e py312-module -- tests/test_smarttable_checker.py tests/test_generate_folder_paths_iterator.py``
+"""
 
 from pathlib import Path
 import pytest
@@ -7,6 +23,7 @@ from unittest.mock import Mock, patch
 
 from rdetoolkit.impl.input_controller import SmartTableChecker
 from rdetoolkit.exceptions import StructuredError
+from rdetoolkit.workflows import generate_folder_paths_iterator
 
 
 class TestSmartTableChecker:
@@ -346,3 +363,71 @@ class TestSmartTableChecker:
             assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("file0.txt"))  # idx=1 -> data/divided/0001 (first row)
             assert rawfiles[2] == (Path("data/temp/row_1.csv"), Path("file1.txt"))  # idx=2 -> data/divided/0002 (second row)
             assert smarttable_path == smarttable_file
+
+    @pytest.mark.parametrize(
+        ("save_table_file", "expected_rawfiles", "expected_rowfiles"),
+        [
+            (
+                True,
+                [
+                    ["smarttable_test.xlsx"],
+                    ["fsmarttable_test_0000.csv", "file0.txt"],
+                    ["fsmarttable_test_0001.csv", "file1.txt"],
+                ],
+                [None, "fsmarttable_test_0000.csv", "fsmarttable_test_0001.csv"],
+            ),
+            (
+                False,
+                [
+                    ["fsmarttable_test_0001.csv", "file1.txt"],
+                    ["fsmarttable_test_0000.csv", "file0.txt"],
+                ],
+                ["fsmarttable_test_0001.csv", "fsmarttable_test_0000.csv"],
+            ),
+        ],
+    )
+    def test_parse_to_generate_folder_paths_iterator_keeps_smarttable_order__tc_ep_smarttable_iter_001_002(
+        self,
+        tmp_path,
+        save_table_file,
+        expected_rawfiles,
+        expected_rowfiles,
+    ):
+        """Test SmartTable parse output as generate_folder_paths_iterator input."""
+        # Given: a SmartTable file whose generated row CSVs follow table order.
+        smarttable_file = tmp_path / "smarttable_test.xlsx"
+        smarttable_file.touch()
+        row0 = tmp_path / "fsmarttable_test_0000.csv"
+        row1 = tmp_path / "fsmarttable_test_0001.csv"
+        related0 = tmp_path / "file0.txt"
+        related1 = tmp_path / "file1.txt"
+        invoice_org_json = tmp_path / "invoice_org.json"
+        invoice_schema_json = tmp_path / "invoice.schema.json"
+
+        with patch("rdetoolkit.impl.input_controller.SmartTableFile") as mock_st:
+            mock_instance = Mock()
+            mock_st.return_value = mock_instance
+            mock_instance.generate_row_csvs_with_file_mapping.return_value = [
+                (row0, (related0,)),
+                (row1, (related1,)),
+            ]
+
+            checker = SmartTableChecker(tmp_path / "temp", save_table_file=save_table_file)
+
+            # When: parse output is consumed by the RDE folder path iterator.
+            rawfiles, _ = checker.parse(tmp_path)
+            resources = list(
+                generate_folder_paths_iterator(
+                    rawfiles,
+                    invoice_org_json,
+                    invoice_schema_json,
+                    smarttable_mode=True,
+                ),
+            )
+
+        # Then: raw file ordering and SmartTable rowfile detection preserve registration order.
+        assert [[path.name for path in resource.rawfiles] for resource in resources] == expected_rawfiles
+        assert [
+            resource.smarttable_rowfile.name if resource.smarttable_rowfile is not None else None
+            for resource in resources
+        ] == expected_rowfiles

--- a/tests/test_smarttable_checker.py
+++ b/tests/test_smarttable_checker.py
@@ -35,9 +35,9 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 3
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Subsequent entries: Each CSV with related files
+            # idx>=1 -> data/divided/000N: data rows in table order
             assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("file1.txt"))
             assert rawfiles[2] == (Path("data/temp/row_1.csv"), Path("file2.txt"))
             assert smarttable_path == smarttable_file
@@ -58,9 +58,9 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 2
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Second entry: CSV file only
+            # idx=1 -> data/divided/0001: data row
             assert rawfiles[1] == (Path("data/temp/row_0.csv"),)
             assert smarttable_path == smarttable_file
 
@@ -80,9 +80,9 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 2
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Second entry: CSV file with related files
+            # idx=1 -> data/divided/0001: data row with related files
             assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("data1.txt"), Path("data2.txt"))
             assert smarttable_path == smarttable_file
 
@@ -111,9 +111,9 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 2
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Second entry: CSV file with extracted file
+            # idx=1 -> data/divided/0001: data row with extracted file
             assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("data/temp/test_content.txt"))
             assert smarttable_path == smarttable_file
 
@@ -200,9 +200,9 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 2
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Second entry: CSV file only
+            # idx=1 -> data/divided/0001: data row
             assert rawfiles[1] == (Path("data/temp/row_0.csv"),)
             assert smarttable_path == smarttable_file
 
@@ -233,11 +233,11 @@ class TestSmartTableChecker:
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
             assert len(rawfiles) == 2
-            # First entry: SmartTable file only
+            # idx=0 -> data/ root: SmartTable file (registered last by RDE)
             assert rawfiles[0] == (smarttable_file,)
-            # Second entry: CSV file + 2 extracted files
+            # idx=1 -> data/divided/0001: data row (CSV file + 2 extracted files)
             assert len(rawfiles[1]) == 3  # CSV file + 2 extracted files
-            assert rawfiles[1][0] == Path("data/temp/row_0.csv")  # First should be CSV file
+            assert rawfiles[1][0] == Path("data/temp/row_0.csv")  # CSV file first within the tuple
             assert smarttable_path == smarttable_file
 
     def test_save_table_file_false(self, tmp_path):
@@ -258,10 +258,11 @@ class TestSmartTableChecker:
             checker = SmartTableChecker(Path("data/temp"))
             rawfiles, smarttable_path = checker.parse(tmp_path)
 
-            # Only CSV files should be in rawfiles, not the SmartTable file
+            # SmartTable file is excluded; the LAST row occupies data/ root (registered
+            # last by RDE) so registration order stays row_0 -> row_1.
             assert len(rawfiles) == 2
-            assert rawfiles[0] == (Path("data/temp/row_0.csv"), Path("file1.txt"))
-            assert rawfiles[1] == (Path("data/temp/row_1.csv"), Path("file2.txt"))
+            assert rawfiles[0] == (Path("data/temp/row_1.csv"), Path("file2.txt"))  # idx=0 -> data/ root (last row)
+            assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("file1.txt"))  # idx=1 -> data/divided/0001 (first row)
             assert smarttable_path == smarttable_file
 
     def test_save_table_file_explicit_false(self, tmp_path):
@@ -282,4 +283,66 @@ class TestSmartTableChecker:
             # Only CSV files should be in rawfiles
             assert len(rawfiles) == 1
             assert rawfiles[0] == (Path("data/temp/row_0.csv"),)
+            assert smarttable_path == smarttable_file
+
+    def test_parse_save_table_file_true_table_at_data_root(self, tmp_path):
+        """Test SmartTable file goes to data/ root when save_table_file=True.
+
+        The RDE system registers data/divided/0001..N first and data/ root LAST,
+        so placing the SmartTable file at idx=0 (data/ root) makes data rows
+        register in table order (row1, row2, ...) followed by the table file:
+        - idx=0 → data/ root (SmartTable file, registered last)
+        - idx=1 → data/divided/0001/ (first data row)
+        - idx=2 → data/divided/0002/ (second data row)
+        """
+        smarttable_file = tmp_path / "smarttable_test.xlsx"
+        smarttable_file.touch()
+
+        with patch('rdetoolkit.impl.input_controller.SmartTableFile') as mock_st:
+            mock_instance = Mock()
+            mock_st.return_value = mock_instance
+            mock_instance.generate_row_csvs_with_file_mapping.return_value = [
+                (Path("data/temp/row_0.csv"), (Path("file1.txt"),)),
+                (Path("data/temp/row_1.csv"), (Path("file2.txt"),)),
+            ]
+
+            checker = SmartTableChecker(Path("data/temp"), save_table_file=True)
+            rawfiles, smarttable_path = checker.parse(tmp_path)
+
+            # SmartTable file occupies data/ root; data rows fill divided in table order
+            assert len(rawfiles) == 3
+            assert rawfiles[0] == (smarttable_file,)  # idx=0 -> data/ root (registered last)
+            assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("file1.txt"))  # idx=1 -> 1st data row
+            assert rawfiles[2] == (Path("data/temp/row_1.csv"), Path("file2.txt"))  # idx=2 -> 2nd data row
+            assert smarttable_path == smarttable_file
+
+    def test_parse_save_table_file_false_last_row_first(self, tmp_path):
+        """Test the LAST data row goes to data/ root when save_table_file=False.
+
+        The RDE system registers data/divided/0001..N first and data/ root LAST, and
+        data/ root must always be registered. With no SmartTable file to occupy it,
+        the final data row is placed at idx=0 so registration order stays row_0..row_2:
+        - idx=0 → data/ root (row_2, the last row, registered last)
+        - idx=1 → data/divided/0001/ (row_0, the first row)
+        - idx=2 → data/divided/0002/ (row_1, the second row)
+        """
+        smarttable_file = tmp_path / "smarttable_test.xlsx"
+        smarttable_file.touch()
+
+        with patch('rdetoolkit.impl.input_controller.SmartTableFile') as mock_st:
+            mock_instance = Mock()
+            mock_st.return_value = mock_instance
+            mock_instance.generate_row_csvs_with_file_mapping.return_value = [
+                (Path("data/temp/row_0.csv"), (Path("file0.txt"),)),
+                (Path("data/temp/row_1.csv"), (Path("file1.txt"),)),
+                (Path("data/temp/row_2.csv"), (Path("file2.txt"),)),
+            ]
+
+            checker = SmartTableChecker(Path("data/temp"), save_table_file=False)
+            rawfiles, smarttable_path = checker.parse(tmp_path)
+
+            assert len(rawfiles) == 3
+            assert rawfiles[0] == (Path("data/temp/row_2.csv"), Path("file2.txt"))  # idx=0 -> data/ root (last row)
+            assert rawfiles[1] == (Path("data/temp/row_0.csv"), Path("file0.txt"))  # idx=1 -> data/divided/0001 (first row)
+            assert rawfiles[2] == (Path("data/temp/row_1.csv"), Path("file1.txt"))  # idx=2 -> data/divided/0002 (second row)
             assert smarttable_path == smarttable_file


### PR DESCRIPTION
### **User description**
## Related Issue
- #479

## Changes
- Fix `SmartTableChecker.parse()` raw_files ordering to match the RDE registration order, where `data/divided/0001..N` are registered first and `data/` root (idx=0) is registered LAST.
- `save_table_file=True`: place the SmartTable file at `data/` root (registered last) and data rows in `data/divided/0001+` in table order. This restores the previously-correct behavior that a prior change had broken.
- `save_table_file=False` (default): place the LAST data row at `data/` root (which must always be registered, and is registered last) and earlier rows in `data/divided/0001+`, so rows register in table order (row1 → row2 → … → rowN).
- Update `tests/test_smarttable_checker.py`: adjust the save_table_file=True/False ordering assertions, rewrite the mis-premised test (`test_parse_save_table_file_true_table_at_data_root`), and add `test_parse_save_table_file_false_last_row_first` documenting the reordering.

## Out of Scope
- RDE database-side registration logic (outside rdetoolkit's scope).
- Pre-existing PBT failures in `tests/property/test_smarttable_invoice_initializer_issue_429.py` (whitespace such as `\r` not rejected for number/boolean fields). These fail on a clean baseline (commit 128cbbc) and are unrelated to this fix; they belong to the #429 validation area.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Fix SmartTable data registration to follow table row order.
  - Ensures RDE registration order: divided/0001..N first, data/ root last.
  - `save_table_file=True`: SmartTable file at data/ root, rows in divided/0001+.
  - `save_table_file=False`: last data row at data/ root, earlier rows in divided/0001+.

- Update and expand SmartTableChecker tests.
  - Adjust assertions for new registration order.
  - Add new tests for both save_table_file modes and edge cases.
  - Parametrize tests to validate row order and folder mapping.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SmartTableChecker.parse() logic"] -- "Fix raw_files ordering" --> B["RDE registration order: divided/0001..N first, data/ root last"]
  B -- "Affects" --> C["save_table_file=True: table file at data/ root"]
  B -- "Affects" --> D["save_table_file=False: last row at data/ root"]
  A -- "Update" --> E["Expanded and revised SmartTableChecker tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>input_controller.py</strong><dd><code>Fix SmartTableChecker raw_files ordering for correct registration</code></dd></summary>
<hr>

src/rdetoolkit/impl/input_controller.py

<ul><li>Fix raw_files ordering in SmartTableChecker.parse() to match RDE <br>registration order.<br> <li> Add detailed docstring about registration order and index mapping.<br> <li> Differentiate logic for save_table_file True/False to preserve row <br>order.</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/485/files#diff-1ba2eed082860db640f1dd55641b7af16fd4566f7f1823cbfb993190871da84c">+19/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_smarttable_checker.py</strong><dd><code>Revise and expand SmartTableChecker tests for new logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_smarttable_checker.py

<ul><li>Update all tests to assert new raw_files ordering and registration <br>logic.<br> <li> Add new tests for save_table_file True/False and edge cases.<br> <li> Parametrize tests to validate registration order and folder mapping.<br> <li> Add detailed test docstrings and equivalence/boundary tables.</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/485/files#diff-d34fbc04cfec67c5722aa5325622e51f523b81a67b5da45459bfeafd0a5e0fc8">+165/-17</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

