### PR TITLE
Fix magic variable documentation examples

### DIFF
--- a/docs/usage/config/magic_variable.en.md
+++ b/docs/usage/config/magic_variable.en.md
@@ -26,7 +26,7 @@ When you include variables listed under **Supported Variables**, RDE structured 
 
 | Variable Name                       | Description                                                                                      | Example                                               |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
-| `${filename}`                       | Raw file name including the extension                                                            | `sample.csv` → `sample.csv`                           |
+| `${filename}`                       | Raw file name including the extension                                                            | `${filename}` → `sample.csv`                          |
 | `${invoice:basic:<field>}`          | Value copied from the `basic` node of the source invoice (`invoice_org`)                         | `${invoice:basic:experimentId}` → `EXP-42`            |
 | `${invoice:custom:<field>}`         | Value copied from the `custom` node of the source invoice                                        | `${invoice:custom:batchId}` → `BATCH-001`             |
 | `${invoice:sample:names}`           | All non-empty entries under `sample.names` joined with `_`                                       | `["alpha", "", "beta"]` → `alpha_beta`                |

--- a/docs/usage/config/magic_variable.ja.md
+++ b/docs/usage/config/magic_variable.ja.md
@@ -17,7 +17,7 @@ RDEToolKitのMagic Variable機能について説明します。ファイル名�
 
 ## Magic Variableの使い方
 
-RDEデータ登録時に、`サポートされる変数`記載の変数を指定すると、ルールに従ってRDE構造化処理内でデータセット名が自動補完されます。
+RDEデータ登録時に、`サポートされる変数`記載の変数を指定すると、ルールに従ってRDE構造化処理内でデータ名（拡張モードではデータタイル名）が自動補完されます。
 
 ローカルでテストする際は、invoice.jsonに事前にMagic Variableを設定してください。(後述)
 
@@ -27,7 +27,7 @@ RDEデータ登録時に、`サポートされる変数`記載の変数を指定
 
 | 変数名                           | 説明                                                                                | 例                                             |
 | -------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- |
-| `${filename}`                    | 拡張子を含んだ元ファイル名                                                          | `sample.csv` → `sample.csv`                    |
+| `${filename}`                    | 拡張子を含んだ元ファイル名                                                          | `${filename}` → `sample.csv`                   |
 | `${invoice:basic:<field>}`       | `invoice_org` の `basic` 配下の値                                                   | `${invoice:basic:experimentId}` → `EXP-42`     |
 | `${invoice:custom:<field>}`      | `invoice_org` の `custom` 配下の値                                                  | `${invoice:custom:batch}` → `B-9`              |
 | `${invoice:sample:names}`        | `sample.names` に含まれる空でない文字列を `_` で連結                                | `["alpha", "", "beta"]` → `alpha_beta`         |


### PR DESCRIPTION
### **User description**
## Related Issue
- #491

## Changes
- Fix `${filename}` examples in Japanese and English magic variable documentation.
- Correct the Japanese description of the auto-completed target from dataset name to data name, with data tile name noted for extended mode.

## Out of Scope
- Runtime behavior changes.

## Verification
- [x] `git diff --check`
- [x] Targeted documentation wording checks


___

### **PR Type**
Documentation


___

### **Description**
- Correct `${filename}` example in English documentation

- Correct `${filename}` example in Japanese documentation

- Update Japanese description for auto-completed target


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["magic_variable.ja.md"] -- "fix example, clarify description" --> B["Improved Japanese documentation"]
  C["magic_variable.en.md"] -- "fix example" --> D["Improved English documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>magic_variable.en.md</strong><dd><code>Fix `${filename}` example in English documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/usage/config/magic_variable.en.md

<ul><li>Corrected the <code>${filename}</code> example to show variable-to-value mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/498/files#diff-4e519727cfc63464e015d9c2c0be22a53bde95e9b4c30c59fcecba7beb101a7a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>magic_variable.ja.md</strong><dd><code>Fix <code>${filename}</code> example and clarify description in Japanese <br>documentation</code></dd></summary>
<hr>

docs/usage/config/magic_variable.ja.md

<ul><li>Corrected the <code>${filename}</code> example to show variable-to-value mapping<br> <li> Clarified description of auto-completed target for magic variables</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/498/files#diff-c7c5dfd8215f61d260d986ca709ebb666f13134c7a48d678df2ca2754e5163c7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

