### PR TITLE
test: robustify package-data and issue-429 property tests

### DIFF
--- a/tests/property/test_smarttable_invoice_initializer_issue_429.py
+++ b/tests/property/test_smarttable_invoice_initializer_issue_429.py
@@ -172,13 +172,23 @@ def _is_invalid_number_string(value: str) -> bool:
 
 def _is_csv_missing_string(value: str) -> bool:
     """Return True when the SmartTable CSV loader normalizes the text to missing."""
+    if value.strip() == "":
+        # Whitespace/control-only strings (e.g. "\r") survive the StringIO
+        # round-trip below as quoted text, but the real SmartTable file loader
+        # normalizes them to missing, so no cast error is ever raised (#429).
+        return True
+
     csv_buffer = io.StringIO()
     writer = csv.DictWriter(csv_buffer, fieldnames=["value"], escapechar="\\")
     writer.writeheader()
     writer.writerow({"value": value})
     csv_buffer.seek(0)
 
-    parsed = pd.read_csv(csv_buffer, dtype=str).iloc[0, 0]
+    parsed_df = pd.read_csv(csv_buffer, dtype=str)
+    if parsed_df.empty or parsed_df.shape[1] == 0:
+        return True
+
+    parsed = parsed_df.iloc[0, 0]
     return bool(pd.isna(parsed) or parsed == "")
 
 

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -4,6 +4,7 @@ This module tests package data configuration to ensure that _agent/*.md files
 are properly included in the wheel distribution and accessible after installation.
 """
 
+import importlib.util
 import subprocess
 import sys
 import zipfile
@@ -20,6 +21,14 @@ except ImportError:
 
 class TestPackageData:
     """Test that guide files are included in package distribution."""
+
+    @staticmethod
+    def _require_build_backend() -> None:
+        """Skip package build tests when the local build backend is unavailable."""
+        if importlib.util.find_spec("build") is None:
+            pytest.skip("build is not installed in the current test environment")
+        if importlib.util.find_spec("maturin") is None:
+            pytest.skip("maturin is not installed in the current test environment")
 
     def test_guide_files_exist_in_source(self) -> None:
         """Test: Guide files exist in source tree."""
@@ -47,10 +56,12 @@ class TestPackageData:
     @pytest.mark.slow
     def test_built_wheel_contains_guide_files(self, tmp_path: Path) -> None:
         """Test: Built wheel contains guide files."""
+        self._require_build_backend()
+
         # Given: Project root
         # When: Building wheel
         result = subprocess.run(
-            ["python", "-m", "build", "--wheel", "--outdir", str(tmp_path)],
+            [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(tmp_path)],
             capture_output=True,
             text=True,
             check=False,
@@ -71,6 +82,8 @@ class TestPackageData:
     @pytest.mark.slow
     def test_installed_package_can_access_guides(self, tmp_path: Path) -> None:
         """Test: Installed package can access guide files."""
+        self._require_build_backend()
+
         # Given: Built and installed package
         venv_dir = tmp_path / "venv"
         subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
@@ -82,7 +95,7 @@ class TestPackageData:
         wheel_dir = tmp_path / "wheels"
         wheel_dir.mkdir()
         subprocess.run(
-            [sys.executable, "-m", "build", "--wheel", "--outdir", str(wheel_dir)],
+            [sys.executable, "-m", "build", "--wheel", "--no-isolation", "--outdir", str(wheel_dir)],
             check=True,
         )
 


### PR DESCRIPTION
### **User description**
## Related Issue
- #429

## Changes
- Skip wheel-build tests when build/maturin are unavailable.
- Use sys.executable and --no-isolation for package-data wheel-build tests.
- Treat whitespace-only strings such as '\r' as CSV-missing in the issue-429 property filter, matching SmartTable loader normalization.

## Out of Scope
- Production code changes.
- Full rewrite of package-data test coverage.

## Verification
- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Tests


___

### **Description**
- Improve robustness of package data tests for missing dependencies
  - Skip wheel-build tests if `build` or `maturin` are unavailable
  - Use `sys.executable` and `--no-isolation` for subprocess calls

- Enhance SmartTable property test normalization
  - Treat whitespace-only strings as missing in CSV normalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_package_data.py"] -- "Add build backend checks, subprocess improvements" --> B["More robust wheel/venv tests"]
  C["test_smarttable_invoice_initializer_issue_429.py"] -- "Whitespace normalization fix" --> D["Accurate CSV-missing detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_package_data.py</strong><dd><code>Robustify package data tests for missing build dependencies</code></dd></summary>
<hr>

tests/test_package_data.py

<ul><li>Add <code>_require_build_backend</code> to skip tests if <code>build</code>/<code>maturin</code> missing<br> <li> Use <code>sys.executable</code> and <code>--no-isolation</code> in subprocess calls<br> <li> Ensure wheel/venv tests only run when environment is ready</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/500/files#diff-d4fbb421910cb32910ee31a9ac405b10c4e680e524ec9373c1b2fda3216a1907">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_smarttable_invoice_initializer_issue_429.py</strong><dd><code>Normalize whitespace-only strings as missing in property tests</code></dd></summary>
<hr>

tests/property/test_smarttable_invoice_initializer_issue_429.py

<ul><li>Treat whitespace-only strings as missing in CSV normalization<br> <li> Improve <code>_is_csv_missing_string</code> to match SmartTable loader behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/500/files#diff-9c461390b2d1bfbea92a8ca11c6c137dc39b4ba61cc092559e9c929a31770471">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

