### PR TITLE
Require metadata-def.json when using SmartTable meta/ columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### SmartTable meta/ Column Now Requires metadata-def.json (#496)
+
+**Breaking change**: In SmartTableInvoice mode, specifying a `meta/<key>` column now raises `StructuredError` if `tasksupport/metadata-def.json` does not exist, instead of silently skipping the column as before. This makes the missing-file case consistent with the existing "key not defined in metadata-def.json" error, so a missing or misplaced `metadata-def.json` is no longer masked as a silent no-op. Templates that do not use `meta/` columns are unaffected.
+
 ## [1.6.4] - 2026-06-03
 
 ### Fixed

--- a/docs/usage/mode/mode_smarttableinvoice.en.md
+++ b/docs/usage/mode/mode_smarttableinvoice.en.md
@@ -60,7 +60,7 @@ This row is read and automatically mapped to `invoice.json` and metadata. The ma
 - `sample/<key in invoice.json>`: mapped to the `sample` section of `invoice.json`.
 - `sample/generalAttributes.<termId>`: mapped to the `value` of the matching `termId` in the `generalAttributes` array.
 - `sample/specificAttributes.<classId>.<termId>`: mapped to the `value` of the matching `classId` and `termId` in the `specificAttributes` array.
-- `meta/<metadata-def key>`: written to the `constant` section of `metadata.json` according to `metadata-def.json` (values are cast using `schema.type`, and `unit` is copied when provided). Entries marked with `variable` are not supported at this time. If `metadata-def.json` is absent, the meta columns are skipped as before.
+- `meta/<metadata-def key>`: written to the `constant` section of `metadata.json` according to `metadata-def.json` (values are cast using `schema.type`, and `unit` is copied when provided). Entries marked with `variable` are not supported at this time. If the `metadata-def.json` file itself is absent, the meta columns are skipped as before.
 - `inputdataX`: specifies a file path inside the ZIP file (X = 1, 2, 3, …).
 
 > Currently, table data is automatically expanded into `invoice.json` and `metadata.json` (for `meta/` columns). Other data is exposed so it can be used by the structured processing.

--- a/docs/usage/mode/mode_smarttableinvoice.en.md
+++ b/docs/usage/mode/mode_smarttableinvoice.en.md
@@ -60,7 +60,7 @@ This row is read and automatically mapped to `invoice.json` and metadata. The ma
 - `sample/<key in invoice.json>`: mapped to the `sample` section of `invoice.json`.
 - `sample/generalAttributes.<termId>`: mapped to the `value` of the matching `termId` in the `generalAttributes` array.
 - `sample/specificAttributes.<classId>.<termId>`: mapped to the `value` of the matching `classId` and `termId` in the `specificAttributes` array.
-- `meta/<metadata-def key>`: written to the `constant` section of `metadata.json` according to `metadata-def.json` (values are cast using `schema.type`, and `unit` is copied when provided). Entries marked with `variable` are not supported at this time. If the `metadata-def.json` file itself is absent, the meta columns are skipped as before.
+- `meta/<metadata-def key>`: written to the `constant` section of `metadata.json` according to `metadata-def.json` (values are cast using `schema.type`, and `unit` is copied when provided). Entries marked with `variable` are not supported at this time. Specifying at least one `meta/` column requires the `tasksupport/metadata-def.json` file to be present. If the file itself is absent, or the specified key is not defined in it, a `StructuredError` is raised.
 - `inputdataX`: specifies a file path inside the ZIP file (X = 1, 2, 3, …).
 
 > Currently, table data is automatically expanded into `invoice.json` and `metadata.json` (for `meta/` columns). Other data is exposed so it can be used by the structured processing.

--- a/docs/usage/mode/mode_smarttableinvoice.ja.md
+++ b/docs/usage/mode/mode_smarttableinvoice.ja.md
@@ -60,7 +60,7 @@ basic/dataName,inputdata1,custom/cycle,custom/thickness,custom/temperature,sampl
 - `sample/<invoice.jsonのキー名>`: invoice.jsonのsampleセクションにマッピングされます。
 - `sample/generalAttributes.<termId>`: `generalAttributes`配列内の該当する`termId`の`value`にマッピング
 - `sample/specificAttributes.<classId>.<termId>`: `specificAttributes`配列内の該当する`classId`と`termId`の`value`にマッピング
-- `meta/<metadata-defのキー>`: `metadata-def.json`の定義に従って`metadata.json`の`constant`セクションへ書き込み（`schema.type`で型変換し、`unit`があれば付与）。`variable`定義は現時点では対応しません。`metadata-def.json`が存在しない場合は従来どおり書き込みをスキップします。
+- `meta/<metadata-defのキー>`: `metadata-def.json`の定義に従って`metadata.json`の`constant`セクションへ書き込み（`schema.type`で型変換し、`unit`があれば付与）。`variable`定義は現時点では対応しません。`metadata-def.json`ファイル自体が存在しない場合は従来どおり書き込みをスキップします。
 - `inputdataX`: zipファイル内のファイルパスを指定（X=1,2,3...）
 
 > 現在自動でテーブルデータの情報が展開される先は、invoice.json と metadata.json（`meta/`列）です。それ以外のデータは、構造化処理で使用できるように展開されます。

--- a/docs/usage/mode/mode_smarttableinvoice.ja.md
+++ b/docs/usage/mode/mode_smarttableinvoice.ja.md
@@ -60,7 +60,7 @@ basic/dataName,inputdata1,custom/cycle,custom/thickness,custom/temperature,sampl
 - `sample/<invoice.jsonのキー名>`: invoice.jsonのsampleセクションにマッピングされます。
 - `sample/generalAttributes.<termId>`: `generalAttributes`配列内の該当する`termId`の`value`にマッピング
 - `sample/specificAttributes.<classId>.<termId>`: `specificAttributes`配列内の該当する`classId`と`termId`の`value`にマッピング
-- `meta/<metadata-defのキー>`: `metadata-def.json`の定義に従って`metadata.json`の`constant`セクションへ書き込み（`schema.type`で型変換し、`unit`があれば付与）。`variable`定義は現時点では対応しません。`metadata-def.json`ファイル自体が存在しない場合は従来どおり書き込みをスキップします。
+- `meta/<metadata-defのキー>`: `metadata-def.json`の定義に従って`metadata.json`の`constant`セクションへ書き込み（`schema.type`で型変換し、`unit`があれば付与）。`variable`定義は現時点では対応しません。`meta/`列を1つでも指定する場合は`tasksupport/metadata-def.json`ファイルの配置が必須です。ファイル自体が存在しない場合や、指定したキーが定義に存在しない場合はエラー（`StructuredError`）となります。
 - `inputdataX`: zipファイル内のファイルパスを指定（X=1,2,3...）
 
 > 現在自動でテーブルデータの情報が展開される先は、invoice.json と metadata.json（`meta/`列）です。それ以外のデータは、構造化処理で使用できるように展開されます。

--- a/src/rdetoolkit/processing/processors/invoice.py
+++ b/src/rdetoolkit/processing/processors/invoice.py
@@ -602,12 +602,6 @@ class SmartTableInvoiceInitializer(Processor):
         Returns the loaded metadata_def if it was lazily loaded, otherwise None.
         """
         if col.startswith("meta/"):
-            if not context.metadata_def_path.exists():
-                logger.debug(
-                    "Skipping meta column %s because metadata-def.json is missing",
-                    col,
-                )
-                return metadata_def
             if metadata_def is None:
                 metadata_def = self._load_metadata_definition(context.metadata_def_path)
             meta_key, meta_entry = self._process_meta_mapping(col, value, metadata_def)

--- a/tests/processing/processors/test_invoice.py
+++ b/tests/processing/processors/test_invoice.py
@@ -315,7 +315,6 @@ class TestSmartTableInvoiceInitializer:
             'sample/names': ['Sample Name'],
             'sample/generalAttributes.term1': ['value1'],
             'sample/specificAttributes.class1.term2': ['value2'],
-            'meta/ignored': ['should be ignored'],
             'inputdata1': ['also ignored'],
         })
         mock_read_csv.return_value = csv_data

--- a/tests/processing/processors/test_invoice_metadata.py
+++ b/tests/processing/processors/test_invoice_metadata.py
@@ -139,7 +139,7 @@ def test_process_metadata_overwrites_existing_value(smarttable_processing_contex
 
 
 def test_process_metadata_def_missing_raises(smarttable_processing_context) -> None:
-    """metadata-def.json が無い場合は StructuredError となることを確認。"""
+    """Verify that StructuredError is raised when metadata-def.json is missing."""
 
     processor = SmartTableInvoiceInitializer()
     context = smarttable_processing_context

--- a/tests/processing/processors/test_invoice_metadata.py
+++ b/tests/processing/processors/test_invoice_metadata.py
@@ -5,7 +5,7 @@
 # | ----------------------------------- | ---------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------- | ----------- |
 # | `SmartTableInvoiceInitializer.process` | predefined meta column                               | verify it can write to metadata.json | converted values are written to metadata.json constant | `TC-EP-001` |
 # | `SmartTableInvoiceInitializer.process` | existing metadata.json has the same key              | verify other fields are preserved on overwrite | only target key is overwritten; other keys and variable are preserved | `TC-EP-002` |
-# | `SmartTableInvoiceInitializer.process` | metadata-def.json is missing                         | verify it is skipped for backward compatibility | metadata.json is not created and processing continues | `TC-EP-003` |
+# | `SmartTableInvoiceInitializer.process` | metadata-def.json is missing                         | verify a meta column requires metadata-def.json | `StructuredError` is raised | `TC-EP-003` |
 # | `SmartTableInvoiceInitializer.process` | meta value is empty/NaN                              | verify boundary behavior for invalid values | metadata.json is not created and the value is skipped | `TC-EP-004` |
 # | `SmartTableInvoiceInitializer.process` | key not defined in metadata-def                       | schema mismatch negative case | `StructuredError` is raised | `TC-EP-005` |
 # | `SmartTableInvoiceInitializer.process` | value cannot be converted                             | type validation negative case | `StructuredError` is raised | `TC-EP-006` |
@@ -138,8 +138,8 @@ def test_process_metadata_overwrites_existing_value(smarttable_processing_contex
     assert metadata["variable"] == [{"cycle": {"value": "A"}}]
 
 
-def test_process_metadata_def_missing_skips_without_error(smarttable_processing_context) -> None:
-    """metadata-def.json が無い場合はスキップされることを確認。"""
+def test_process_metadata_def_missing_raises(smarttable_processing_context) -> None:
+    """metadata-def.json が無い場合は StructuredError となることを確認。"""
 
     processor = SmartTableInvoiceInitializer()
     context = smarttable_processing_context
@@ -154,10 +154,9 @@ def test_process_metadata_def_missing_skips_without_error(smarttable_processing_
         ["note", "dataset"],
     )
 
-    # When: processing the SmartTable row
-    processor.process(context)
-
-    # Then: metadata.json is not created and processing completes
+    # When/Then: StructuredError is raised because metadata-def.json is missing
+    with pytest.raises(StructuredError, match="metadata-def.json not found"):
+        processor.process(context)
     assert not context.metadata_path.exists()
 
 

--- a/tests/processing/processors/test_invoice_smarttable.py
+++ b/tests/processing/processors/test_invoice_smarttable.py
@@ -27,7 +27,6 @@ class TestSmartTableInvoiceInitializerIntegration:
             'sample/names': ['Sample Name'],
             'sample/generalAttributes.term1': ['value1'],
             'sample/specificAttributes.class1.term2': ['value2'],
-            'meta/ignored': ['should be ignored'],
             'inputdata1': ['also ignored'],
         })
 


### PR DESCRIPTION
### **User description**
## Related Issue

- #496

## Changes

- In SmartTableInvoice mode, specifying a `meta/<key>` column now raises `StructuredError` when `tasksupport/metadata-def.json` does not exist, instead of silently skipping the column (breaking change).
- Updated `mode_smarttableinvoice.ja.md` / `.en.md` to describe the new required-file behavior.
- Updated tests in `test_invoice_metadata.py`, `test_invoice.py`, and `test_invoice_smarttable.py` to match the new behavior.
- Added a CHANGELOG entry under `[Unreleased]` documenting the breaking change.

## Out of Scope

- No change to the existing "undefined key in metadata-def.json" error path (already raised `StructuredError`).
- No change for templates that do not use `meta/` columns.

## Verification

- [ ] CI tests pass successfully
- [ ] No issues with the modified scripts


___

### **PR Type**
Bug fix, Documentation, Tests


___

### **Description**
- Require metadata-def.json for SmartTable meta/ columns
  - Raise StructuredError if missing, not silent skip
  - Consistent error for missing file or key

- Update documentation to clarify new error behavior

- Update and fix tests for new error path

- Add CHANGELOG entry for breaking change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SmartTable meta/ column specified"] -- "metadata-def.json missing" --> B["Raise StructuredError"]
  A -- "metadata-def.json present, key missing" --> C["Raise StructuredError"]
  A -- "metadata-def.json present, key present" --> D["Write to metadata.json"]
  B -- "Error message" --> E["User notified"]
  C -- "Error message" --> E
  D -- "Success" --> F["Processing continues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>invoice.py</strong><dd><code>Enforce error if metadata-def.json missing for meta/ columns</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-2bad8b90d4f46b258fc1d0835a5b4a88ac12e041809e82712f0450b5bb663676">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>mode_smarttableinvoice.ja.md</strong><dd><code>Clarify meta/ columns require metadata-def.json (Japanese)</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-8e95659ad8397a6fc8575dbb4f82f14df0f070c221ee7dffaf087a8abe4c66be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mode_smarttableinvoice.en.md</strong><dd><code>Clarify meta/ columns require metadata-def.json (English)</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-3e74448669ca80c6739cde9535a7b9730f57f96502d171de21283559b2a3ba45">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Add breaking change note for meta/ column behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_invoice_metadata.py</strong><dd><code>Update tests: expect error if metadata-def.json missing</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-dc1facde233b28a5ffbdd2220ba9be5df5ed172cf5e71f6480bfd10e0f2ce33c">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_invoice.py</strong><dd><code>Remove meta/ignored column from test data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-dd392c5619d625e117d1d08ac768c1172b5c9f3174b58ad6950c019ecbb6a785">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_invoice_smarttable.py</strong><dd><code>Remove meta/ignored column from test data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/505/files#diff-15640c71a36f52ec9f869387a3dd9cfa2a25e13cd02fcd72adba837e0b41d171">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

