### PR TITLE
test: generate only CSV-representable text in issue-429 property strategies

### DIFF
--- a/tests/property/test_smarttable_invoice_initializer_issue_429.py
+++ b/tests/property/test_smarttable_invoice_initializer_issue_429.py
@@ -197,10 +197,21 @@ def _is_invalid_boolean_string(value: str) -> bool:
     return value.strip().lower() not in {"true", "false"}
 
 
-invalid_number_strings = st.text(min_size=1, max_size=20).filter(
+# Control characters (e.g. NUL, CR) do not survive the CSV file round-trip the
+# way the StringIO probe predicts: the real SmartTable loader normalizes them
+# away, so the expected cast error never fires (Hypothesis counterexamples
+# '\r' and '0\x00'). Generate only printable, non-surrogate text — the realistic
+# content of a hand-authored CSV cell.
+_csv_representable_text = st.text(
+    alphabet=st.characters(blacklist_categories=("Cc", "Cs")),
+    min_size=1,
+    max_size=20,
+)
+
+invalid_number_strings = _csv_representable_text.filter(
     lambda value: _is_invalid_number_string(value) and not _is_csv_missing_string(value),
 )
-invalid_boolean_strings = st.text(min_size=1, max_size=20).filter(
+invalid_boolean_strings = _csv_representable_text.filter(
     lambda value: _is_invalid_boolean_string(value) and not _is_csv_missing_string(value),
 )
 

--- a/tests/property/test_smarttable_invoice_initializer_issue_429.py
+++ b/tests/property/test_smarttable_invoice_initializer_issue_429.py
@@ -197,16 +197,20 @@ def _is_invalid_boolean_string(value: str) -> bool:
     return value.strip().lower() not in {"true", "false"}
 
 
-# Control characters (e.g. NUL, CR) do not survive the CSV file round-trip the
-# way the StringIO probe predicts: the real SmartTable loader normalizes them
-# away, so the expected cast error never fires (Hypothesis counterexamples
-# '\r' and '0\x00'). Generate only printable, non-surrogate text — the realistic
-# content of a hand-authored CSV cell.
+# Non-printable characters (NUL, CR, zero-width/format chars, line/paragraph
+# separators, ...) do not survive the CSV file round-trip the way the StringIO
+# probe predicts: the real SmartTable loader normalizes them away, so the
+# expected cast error never fires (Hypothesis counterexamples '\r' and
+# '0\x00'). Generate only printable text — the realistic content of a
+# hand-authored CSV cell. The category blacklist ("C" = all control/format/
+# surrogate/private/unassigned, "Zl"/"Zp" = line/paragraph separators) does the
+# bulk of the work; the str.isprintable() filter guarantees the stated intent
+# for anything the categories miss.
 _csv_representable_text = st.text(
-    alphabet=st.characters(blacklist_categories=("Cc", "Cs")),
+    alphabet=st.characters(blacklist_categories=("C", "Zl", "Zp")),
     min_size=1,
     max_size=20,
-)
+).filter(str.isprintable)
 
 invalid_number_strings = _csv_representable_text.filter(
     lambda value: _is_invalid_number_string(value) and not _is_csv_missing_string(value),


### PR DESCRIPTION
### **User description**
## 概要

issue-429 プロパティテストの生成戦略を「CSV セルとして現実的な文字のみ」(Unicode カテゴリ `Cc`(制御文字)/ `Cs`(サロゲート)を除外)に制限する。

## 背景

Hypothesis が制御文字系の反例を繰り返し発見している(#500 で `'\r'`、今回 v2 開発ブランチの full suite で `'0\x00'`)。原因は共通で、テスト内の StringIO ラウンドトリップ判定(`_is_csv_missing_string`)と実際の SmartTable ファイルローダの正規化が制御文字で乖離するため、「無効値なら cast エラー」という期待が成立しないこと。

フィルタ関数を反例ごとに強化するいたちごっこをやめ、**生成側で制御文字を除外**する(手書き CSV セルに NUL や生 CR が入ることは現実的でなく、テストの意図である「無効な数値/真偽値文字列の reject 検証」の網羅性は保たれる)。

## 検証

- 修正前: `test_smarttable_number_property_rejects_invalid_strings__tc_ep_429_010` が `raw_value='0\x00'` で FAILED(キャッシュ再生)
- 修正後: **full suite 1910 passed / 3 skipped / 0 failed**(同キャッシュ再生下)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Tests


___

### **Description**
- Restrict property test string generation to printable, CSV-safe characters

- Use Unicode category blacklists and isprintable filter for test data

- Prevent control/format character counterexamples in property tests

- Align test string normalization with SmartTable loader behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_smarttable_invoice_initializer_issue_429.py"] -- "Use printable, CSV-safe string strategy" --> B["No control/format char counterexamples"]
  B -- "Test normalization matches loader" --> C["Reliable property test outcomes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_smarttable_invoice_initializer_issue_429.py</strong><dd><code>Restrict property test strings to printable, CSV-safe characters</code></dd></summary>
<hr>

tests/property/test_smarttable_invoice_initializer_issue_429.py

<ul><li>Add _csv_representable_text strategy for printable, CSV-safe strings<br> <li> Blacklist Unicode control/format/surrogate/sep categories in test data<br> <li> Apply isprintable filter to ensure realistic CSV cell content<br> <li> Update invalid_number_strings and invalid_boolean_strings to use new <br>strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/509/files#diff-9c461390b2d1bfbea92a8ca11c6c137dc39b4ba61cc092559e9c929a31770471">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

