### PR TITLE
fix: decode cp932 zip filenames correctly in SmartTable and other extraction modes

### DIFF
--- a/docs/releases/index.en.md
+++ b/docs/releases/index.en.md
@@ -4,7 +4,8 @@
 
 | Version | Release Date | Key Changes | Details |
 | ------- | ------------ | ----------- | ------- |
-| v1.7.0  | unreleased   | **BREAKING**: SmartTable row CSV excluded from `rawfiles` / `smarttable_rowfile` renamed to `smarttable_rawfile` / `save_table_file: true` original file now registers at `divided/0001` / SmartTable `meta/` columns now require `metadata-def.json` / csv2graph legend placement policy and axis tick label formatting added | [v1.7.0](#v170-unreleased) |
+| v1.7.1  | unreleased   | Decode cp932 filenames correctly when extracting ZIP archives created on Japanese Windows / Protect ZIP extraction from path traversal | [v1.7.1](#v171-unreleased) |
+| v1.7.0  | 2026-07-13   | **BREAKING**: SmartTable row CSV excluded from `rawfiles` / `smarttable_rowfile` renamed to `smarttable_rawfile` / `save_table_file: true` original file now registers at `divided/0001` / SmartTable `meta/` columns now require `metadata-def.json` / csv2graph legend placement policy and axis tick label formatting added | [v1.7.0](#v170-2026-07-13) |
 | v1.6.4  | 2026-06-03   | Fix SmartTable data registration order to follow table row order / Remove direct click dependency from CLI | [v1.6.4](#v164-2026-06-03) |
 | v1.6.3  | 2026-04-13   | Fix SmartTable new sample `sampleId` set to None instead of empty string / Support uppercase image extensions in thumbnail copy | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2  | 2026-03-16   | Fix silent inheritance of dummy sampleId when SmartTable specifies `sample/names` / Improve error messages for missing SmartTable file references in zip | [v1.6.2](#v162-2026-03-16) |
@@ -26,7 +27,43 @@
 
 # Release Details
 
-## v1.7.0 (unreleased)
+## v1.7.1 (unreleased)
+
+!!! info "References"
+    - Key issue: [#515](https://github.com/nims-mdpf/rdetoolkit/issues/515)
+    - Pull request: [#518](https://github.com/nims-mdpf/rdetoolkit/pull/518)
+
+#### Highlights
+
+- Fixed garbled filenames when extracting ZIP archives created on Japanese
+  Windows with cp932-encoded entry names and no UTF-8 language-encoding flag
+- Applied the filename recovery consistently across SmartTable, RDEFormat,
+  MultiFile, and ExcelInvoice file/folder extraction paths
+- Preserved UTF-8 and ASCII filenames, including archives that mix flagged
+  UTF-8 entries with unflagged cp932 entries
+- Added path validation to ZIP extraction; entries that resolve outside the
+  destination directory are logged and skipped to prevent path traversal
+
+### Bug Fixes
+
+#### Decode cp932 ZIP Filenames Correctly (Issue #515)
+
+**Problem**: Python's `zipfile` decodes entry names as cp437 when the ZIP
+language-encoding flag is absent. ZIP archives created on Japanese Windows may
+store those names as cp932 without setting the flag, causing SmartTable file
+references containing Japanese or multibyte characters to become garbled and
+fail validation.
+
+**Changes**:
+
+- Recover the original filename bytes from `zipfile`'s cp437 representation
+  and decode them as cp932
+- Fall back to encoding detection only when cp932 decoding fails
+- Use one shared extraction helper for every affected input mode
+- Verify each resolved entry remains inside the extraction directory before
+  writing it
+
+## v1.7.0 (2026-07-13)
 
 !!! warning "Breaking Changes"
     In SmartTable invoice mode, `paths.rawfiles` no longer contains the

--- a/docs/releases/index.ja.md
+++ b/docs/releases/index.ja.md
@@ -4,7 +4,8 @@
 
 | バージョン | リリース日 | 主な変更点 | 詳細セクション |
 | ---------- | ---------- | ---------- | -------------- |
-| v1.7.0     | unreleased | **破壊的変更**: SmartTableの行CSVを`rawfiles`から除外 / `smarttable_rowfile`を`smarttable_rawfile`に改名 / `save_table_file: true`時の元ファイル登録先を`divided/0001`に変更 / SmartTableの`meta/`列に`metadata-def.json`を必須化 / csv2graphに凡例配置ポリシーと軸目盛りフォーマットを追加 | [v1.7.0](#v170-unreleased) |
+| v1.7.1     | unreleased | 日本語Windowsで作成されたZIPのcp932ファイル名を正しくデコード / ZIP展開時のパストラバーサルを防止 | [v1.7.1](#v171-unreleased) |
+| v1.7.0     | 2026-07-13 | **破壊的変更**: SmartTableの行CSVを`rawfiles`から除外 / `smarttable_rowfile`を`smarttable_rawfile`に改名 / `save_table_file: true`時の元ファイル登録先を`divided/0001`に変更 / SmartTableの`meta/`列に`metadata-def.json`を必須化 / csv2graphに凡例配置ポリシーと軸目盛りフォーマットを追加 | [v1.7.0](#v170-2026-07-13) |
 | v1.6.4     | 2026-06-03 | SmartTableデータ登録順序をテーブル行順に修正 / CLIからclick直接依存を除去 | [v1.6.4](#v164-2026-06-03) |
 | v1.6.3     | 2026-04-13 | SmartTable新規試料登録時の`sampleId`を空文字ではなく`None`に修正 / サムネイルコピーで大文字画像拡張子をサポート | [v1.6.3](#v163-2026-04-13) |
 | v1.6.2     | 2026-03-16 | SmartTableで`sample/names`指定時にダミー試料の`sampleId`が黙って継承される問題を修正 / SmartTableのファイル参照がzip内に存在しない場合のエラーメッセージ改善 | [v1.6.2](#v162-2026-03-16) |
@@ -26,7 +27,42 @@
 
 # リリース詳細
 
-## v1.7.0 (unreleased)
+## v1.7.1 (unreleased)
+
+!!! info "参照"
+    - 主な課題: [#515](https://github.com/nims-mdpf/rdetoolkit/issues/515)
+    - プルリクエスト: [#518](https://github.com/nims-mdpf/rdetoolkit/pull/518)
+
+#### ハイライト
+
+- 日本語Windowsで作成され、UTF-8言語エンコーディングフラグが設定されて
+  いないZIPについて、cp932で格納されたエントリ名の文字化けを修正
+- SmartTable、RDEFormat、MultiFile、ExcelInvoiceのファイル・フォルダ
+  展開処理へファイル名復元を一貫して適用
+- UTF-8・ASCIIファイル名、およびUTF-8フラグ付きエントリとcp932の
+  フラグなしエントリが混在するZIPを引き続きサポート
+- ZIPエントリの展開先を検証し、出力先ディレクトリ外へ解決される
+  エントリを警告付きでスキップすることでパストラバーサルを防止
+
+### バグ修正
+
+#### cp932のZIPファイル名を正しくデコード (Issue #515)
+
+**問題**: Pythonの`zipfile`は、ZIPの言語エンコーディングフラグがない
+エントリ名をcp437としてデコードします。日本語Windowsで作成されたZIPは、
+フラグを設定せずにcp932でエントリ名を格納する場合があるため、日本語や
+マルチバイト文字を含むSmartTableのファイル参照が文字化けし、検証に
+失敗していました。
+
+**修正内容**:
+
+- `zipfile`がcp437として表現したファイル名から元のバイト列を復元し、
+  cp932としてデコード
+- cp932でデコードできない場合のみ文字コード検出へフォールバック
+- 影響を受けるすべての入力モードで共通のZIP展開ヘルパを使用
+- 書き込み前に、解決後の各エントリが展開先ディレクトリ内に収まることを検証
+
+## v1.7.0 (2026-07-13)
 
 !!! warning "破壊的変更"
     SmartTableInvoiceモードにおいて、`paths.rawfiles`に自動生成される行CSVが

--- a/src/rdetoolkit/impl/_zip_encoding.py
+++ b/src/rdetoolkit/impl/_zip_encoding.py
@@ -95,14 +95,20 @@ def extract_zip_with_encoding(zip_path: Path | str, extract_path: Path | str) ->
     Example:
         >>> extract_zip_with_encoding("archive.zip", "outdir")
     """
+    base_dir = Path(extract_path).resolve()
+
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for zip_info in zip_ref.infolist():
-            old_filename = zip_info.filename
             resolved = resolve_filename(zip_info)
+            destination = (base_dir / resolved).resolve()
 
-            if resolved != old_filename:
+            if destination != base_dir and base_dir not in destination.parents:
+                logger.warning(
+                    f"Skipping unsafe zip entry {resolved!r}: path resolves outside {str(base_dir)!r}",
+                )
+                continue
+
+            if resolved != zip_info.filename:
                 zip_info.filename = resolved
-                zip_ref.NameToInfo[resolved] = zip_info
-                del zip_ref.NameToInfo[old_filename]
 
-            zip_ref.extract(zip_info, extract_path)
+            zip_ref.extract(zip_info, base_dir)

--- a/src/rdetoolkit/impl/_zip_encoding.py
+++ b/src/rdetoolkit/impl/_zip_encoding.py
@@ -1,0 +1,108 @@
+"""Shared helpers for extracting ZIP archives whose filenames are not UTF-8.
+
+The ZIP specification only guarantees the filename encoding when general purpose
+bit 11 (the language encoding flag, ``0x800``) is set, in which case the name is
+UTF-8. When the flag is absent, :mod:`zipfile` falls back to decoding the raw
+bytes as cp437 for historical reasons. Archives produced on Japanese Windows
+store filenames as cp932, so cp437 decoding turns ``2θ_θ.TXT`` into
+``2â╞_â╞.TXT``.
+
+Because cp437 maps every byte to a character, that mis-decoding is lossless and
+therefore reversible: re-encoding the mojibake string as cp437 recovers the
+original bytes, which can then be decoded with the true encoding.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Final
+
+import charset_normalizer
+
+from rdetoolkit.rdelogger import get_logger
+
+logger = get_logger(__name__)
+
+# ZIP general purpose bit flag 11: filenames are UTF-8 when set.
+LANG_ENC_FLAG: Final = 0x800
+
+# Encoding zipfile uses for filenames when LANG_ENC_FLAG is absent.
+FALLBACK_ENCODING: Final = "cp437"
+
+# Tried before statistical detection: RDE archives originate on Japanese Windows,
+# and charset_normalizer misreads short cp932 filenames (see resolve_filename).
+PREFERRED_ENCODING: Final = "cp932"
+
+
+def resolve_filename(zip_info: zipfile.ZipInfo) -> str:
+    """Recover the true filename for a ZIP entry.
+
+    ``zipfile`` has already decoded ``zip_info.filename`` by the time this is
+    called: as UTF-8 when the language encoding flag is set, otherwise as cp437.
+    This function decides whether that decoding can be trusted and, when it
+    cannot, re-decodes the name using the encoding the bytes are actually in.
+
+    cp932 is tried before statistical detection because
+    ``charset_normalizer.detect()`` needs more data than a filename carries to be
+    reliable: it reads ``NB1_800_20220214_2θ_θ.TXT`` as cp949 and ``データ.txt``
+    as utf_16_le, corrupting both. Detection is kept only for names cp932 cannot
+    decode at all.
+
+    Args:
+        zip_info (zipfile.ZipInfo): Entry metadata as parsed by :mod:`zipfile`.
+
+    Returns:
+        str: The filename to extract the entry under. Falls back to the name
+            :mod:`zipfile` produced when the true encoding cannot be determined.
+    """
+    # The spec guarantees UTF-8 here, so zipfile already decoded it correctly.
+    # Running detection anyway risks corrupting a name that is already right.
+    if zip_info.flag_bits & LANG_ENC_FLAG:
+        return zip_info.filename
+
+    # cp437 maps all 256 byte values, so this round-trips back to the raw bytes.
+    raw = zip_info.filename.encode(FALLBACK_ENCODING)
+
+    try:
+        return raw.decode(PREFERRED_ENCODING)
+    except UnicodeDecodeError:
+        pass
+
+    detected = charset_normalizer.detect(raw)
+    encoding = detected.get("encoding") or FALLBACK_ENCODING
+    try:
+        return raw.decode(encoding)
+    except (UnicodeDecodeError, LookupError):
+        # Detection is heuristic; one unreadable name must not abort the archive.
+        logger.warning(
+            f"Failed to decode zip entry filename as {encoding!r}; extracting as {zip_info.filename!r}",
+        )
+        return zip_info.filename
+
+
+def extract_zip_with_encoding(zip_path: Path | str, extract_path: Path | str) -> None:
+    """Extract a ZIP archive, repairing filenames that are not UTF-8.
+
+    Each entry's name is resolved via :func:`resolve_filename` before extraction,
+    so archives created on non-UTF-8 platforms (notably cp932 on Japanese
+    Windows) land on disk under their original names instead of mojibake.
+
+    Args:
+        zip_path (Path | str): Path to the ZIP archive to extract.
+        extract_path (Path | str): Directory to extract the archive into.
+
+    Example:
+        >>> extract_zip_with_encoding("archive.zip", "outdir")
+    """
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        for zip_info in zip_ref.infolist():
+            old_filename = zip_info.filename
+            resolved = resolve_filename(zip_info)
+
+            if resolved != old_filename:
+                zip_info.filename = resolved
+                zip_ref.NameToInfo[resolved] = zip_info
+                del zip_ref.NameToInfo[old_filename]
+
+            zip_ref.extract(zip_info, extract_path)

--- a/src/rdetoolkit/impl/_zip_encoding.pyi
+++ b/src/rdetoolkit/impl/_zip_encoding.pyi
@@ -1,0 +1,13 @@
+import zipfile
+from _typeshed import Incomplete
+from pathlib import Path
+from rdetoolkit.rdelogger import get_logger as get_logger
+from typing import Final
+
+logger: Incomplete
+LANG_ENC_FLAG: Final[int]
+FALLBACK_ENCODING: Final[str]
+PREFERRED_ENCODING: Final[str]
+
+def resolve_filename(zip_info: zipfile.ZipInfo) -> str: ...
+def extract_zip_with_encoding(zip_path: Path | str, extract_path: Path | str) -> None: ...

--- a/src/rdetoolkit/impl/_zip_encoding.pyi
+++ b/src/rdetoolkit/impl/_zip_encoding.pyi
@@ -1,10 +1,9 @@
+import logging
 import zipfile
-from _typeshed import Incomplete
 from pathlib import Path
-from rdetoolkit.rdelogger import get_logger as get_logger
 from typing import Final
 
-logger: Incomplete
+logger: logging.Logger
 LANG_ENC_FLAG: Final[int]
 FALLBACK_ENCODING: Final[str]
 PREFERRED_ENCODING: Final[str]

--- a/src/rdetoolkit/impl/compressed_controller.py
+++ b/src/rdetoolkit/impl/compressed_controller.py
@@ -6,13 +6,12 @@ import shutil
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Final
 from collections.abc import Callable
 
-import charset_normalizer
 import pandas as pd
 
 from rdetoolkit.exceptions import StructuredError
+from rdetoolkit.impl._zip_encoding import extract_zip_with_encoding
 from rdetoolkit.interfaces.filechecker import IArtifactPackageCompressor, ICompressedFileStructParser
 from rdetoolkit.invoicefile import check_exist_rawfiles
 from rdetoolkit.rdelogger import get_logger
@@ -218,30 +217,12 @@ class CompressedFlatFileParser(ICompressedFileStructParser):
             zip_path (Path | str): The path to the ZIP file to be extracted.
             extract_path (Path | str): The directory where the contents of the ZIP file will be extracted.
 
-        Raises:
-            ValueError: If encoding detection fails for any filename within the ZIP archive.
-            UnicodeDecodeError: If a filename cannot be decoded with the detected or specified encoding.
-
         Example:
             >>> zip_path = 'path/to/your/archive.zip'
             >>> extract_path = 'path/to/extract/directory'
-            >>> encoding = 'utf-8'  # or 'cp932' for Japanese text, for example
             >>> self._extract_zip_with_encoding(zip_path, extract_path)
         """
-        lang_enc_flag: Final = 0x800
-        with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            for zip_info in zip_ref.infolist():
-                old_filename = zip_info.filename
-                encoding = "utf-8" if zip_info.flag_bits & lang_enc_flag else "cp437"
-                enc = charset_normalizer.detect(zip_info.filename.encode(encoding))
-                if not enc.get("encoding"):
-                    enc["encoding"] = encoding
-
-                zip_info.filename = zip_info.filename.encode(encoding).decode(str(enc["encoding"]))
-                zip_ref.NameToInfo[zip_info.filename] = zip_info
-                del zip_ref.NameToInfo[old_filename]
-
-                zip_ref.extract(zip_info, extract_path)
+        extract_zip_with_encoding(zip_path, extract_path)
 
     def _is_excluded(self, file: Path) -> bool:
         """Checks a specific file pattern to determine whether it should be excluded.
@@ -317,30 +298,12 @@ class CompressedFolderParser(ICompressedFileStructParser):
             zip_path (Path | str): The path to the ZIP file to be extracted.
             extract_path (Path | str): The directory where the contents of the ZIP file will be extracted.
 
-        Raises:
-            ValueError: If encoding detection fails for any filename within the ZIP archive.
-            UnicodeDecodeError: If a filename cannot be decoded with the detected or specified encoding.
-
         Example:
             >>> zip_path = 'path/to/your/archive.zip'
             >>> extract_path = 'path/to/extract/directory'
-            >>> encoding = 'utf-8'  # or 'cp932' for Japanese text, for example
             >>> self._extract_zip_with_encoding(zip_path, extract_path)
         """
-        lang_enc_flag: Final = 0x800
-        with zipfile.ZipFile(zip_path, "r") as zip_ref:
-            for zip_info in zip_ref.infolist():
-                old_filename = zip_info.filename
-                encoding = "utf-8" if zip_info.flag_bits & lang_enc_flag else "cp437"
-                enc = charset_normalizer.detect(zip_info.filename.encode(encoding))
-                if not enc.get("encoding"):
-                    enc["encoding"] = encoding
-
-                zip_info.filename = zip_info.filename.encode(encoding).decode(str(enc["encoding"]))
-                zip_ref.NameToInfo[zip_info.filename] = zip_info
-                del zip_ref.NameToInfo[old_filename]
-
-                zip_ref.extract(zip_info, extract_path)
+        extract_zip_with_encoding(zip_path, extract_path)
 
     def _is_excluded(self, file: Path) -> bool:
         """Checks a specific file pattern to determine whether it should be excluded.

--- a/src/rdetoolkit/impl/input_controller.py
+++ b/src/rdetoolkit/impl/input_controller.py
@@ -301,10 +301,10 @@ class RDEFormatChecker(IInputFileChecker):
         return [f for f in input_files if f.suffix.lower() == ".zip"]
 
     def _unpacked(self, zip_path: Path, target_dir: Path) -> list[Path]:
-        extract_zip_with_encoding(zip_path, self.out_dir_temp)
+        extract_zip_with_encoding(zip_path, target_dir)
 
         cleaner = SystemFilesCleaner()
-        removed_paths = cleaner.clean_directory(self.out_dir_temp)
+        removed_paths = cleaner.clean_directory(target_dir)
         if removed_paths:
             logger.info(f"Removed {len(removed_paths)} system/temporary files after extraction")
 
@@ -376,11 +376,11 @@ class MultiFileChecker(IInputFileChecker):
         return [f for f in input_files if f not in excel_invoice_files]
 
     def _unpacked(self, zip_path: Path, target_dir: Path) -> list[Path]:
-        extract_zip_with_encoding(zip_path, self.out_dir_temp)
+        extract_zip_with_encoding(zip_path, target_dir)
 
         # Clean up system files after extraction
         cleaner = SystemFilesCleaner()
-        removed_paths = cleaner.clean_directory(self.out_dir_temp)
+        removed_paths = cleaner.clean_directory(target_dir)
         if removed_paths:
             logger.info(f"Removed {len(removed_paths)} system/temporary files after extraction")
 

--- a/src/rdetoolkit/impl/input_controller.py
+++ b/src/rdetoolkit/impl/input_controller.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import re
-import shutil
 from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
 
 from rdetoolkit.exceptions import StructuredError
 from rdetoolkit.impl import compressed_controller
+from rdetoolkit.impl._zip_encoding import extract_zip_with_encoding
 from rdetoolkit.impl.compressed_controller import SystemFilesCleaner
 from rdetoolkit.interfaces.filechecker import IInputFileChecker
 from rdetoolkit.invoicefile import ExcelInvoiceFile, SmartTableFile
@@ -300,8 +300,8 @@ class RDEFormatChecker(IInputFileChecker):
     def _get_zipfiles(self, input_files: list[Path]) -> ZipFilesPathList:
         return [f for f in input_files if f.suffix.lower() == ".zip"]
 
-    def _unpacked(self, zipfile: Path, target_dir: Path) -> list[Path]:
-        shutil.unpack_archive(zipfile, self.out_dir_temp)
+    def _unpacked(self, zip_path: Path, target_dir: Path) -> list[Path]:
+        extract_zip_with_encoding(zip_path, self.out_dir_temp)
 
         cleaner = SystemFilesCleaner()
         removed_paths = cleaner.clean_directory(self.out_dir_temp)
@@ -375,8 +375,8 @@ class MultiFileChecker(IInputFileChecker):
         excel_invoice_files = [f for f in input_files if f.suffix.lower() in [".xls", ".xlsx"] and f.stem.endswith("_excel_invoice")]
         return [f for f in input_files if f not in excel_invoice_files]
 
-    def _unpacked(self, zipfile: Path, target_dir: Path) -> list[Path]:
-        shutil.unpack_archive(zipfile, self.out_dir_temp)
+    def _unpacked(self, zip_path: Path, target_dir: Path) -> list[Path]:
+        extract_zip_with_encoding(zip_path, self.out_dir_temp)
 
         # Clean up system files after extraction
         cleaner = SystemFilesCleaner()
@@ -494,16 +494,20 @@ class SmartTableChecker(IInputFileChecker):
 
         return raw_files, smarttable_file
 
-    def _unpacked_smarttable(self, zipfile: Path) -> list[Path]:
+    def _unpacked_smarttable(self, zip_path: Path) -> list[Path]:
         """Extract zip file to temporary directory.
 
+        Filenames are decoded with :func:`extract_zip_with_encoding` rather than
+        ``shutil.unpack_archive``, so archives created on non-UTF-8 platforms
+        (notably cp932 on Japanese Windows) keep their original filenames.
+
         Args:
-            zipfile (Path): Path to the zip file to extract.
+            zip_path (Path): Path to the zip file to extract.
 
         Returns:
             list[Path]: List of extracted file paths.
         """
-        shutil.unpack_archive(zipfile, self.out_dir_temp)
+        extract_zip_with_encoding(zip_path, self.out_dir_temp)
 
         # Clean up system files after extraction
         cleaner = SystemFilesCleaner()

--- a/tests/test_smarttable_checker_zip_encoding.py
+++ b/tests/test_smarttable_checker_zip_encoding.py
@@ -31,6 +31,7 @@ Equivalence Partitioning:
 | ``_unpacked_smarttable`` | UTF-8-encoded filename, UTF-8 flag set | modern zip tools / Python zipfile default | extracted filename unchanged (no regression) | TC-EP-ZIPENC-002 |
 | ``_unpacked_smarttable`` | ASCII-only filename | common case | extracted filename unchanged | TC-EP-ZIPENC-003 |
 | ``_unpacked_smarttable`` | zip mixing a UTF-8-flagged entry and a cp932-unflagged entry | real-world archives may mix tools | both filenames correctly resolved | TC-EP-ZIPENC-004 |
+| ``_unpacked`` | explicit target differs from configured temp directory | caller-provided extraction contract | extracts, cleans, and lists files from target | TC-EP-ZIPENC-007 |
 
 Validation commands:
 Direct: ``uv run pytest tests/test_smarttable_checker_zip_encoding.py -v``
@@ -301,3 +302,24 @@ class TestOtherCheckersZipEncoding:
 
         # Then: the filename is unchanged.
         assert [f.name for f in extracted] == ["日本語ファイル.txt"]
+
+    def test_explicit_target_directory_is_used__tc_ep_zipenc_007(
+        self,
+        checker_cls: type[RDEFormatChecker | MultiFileChecker],
+        tmp_path: Path,
+    ) -> None:
+        """TC-EP-ZIPENC-007: extraction honors the caller-provided target."""
+        # Given: a checker configured with a different directory from the target.
+        zip_path = tmp_path / "input.zip"
+        with zipfile.ZipFile(zip_path, "w") as zip_ref:
+            zip_ref.writestr("data.txt", b"dummy")
+        configured_dir = tmp_path / "configured"
+        target_dir = tmp_path / "target"
+        checker = checker_cls(configured_dir)
+
+        # When: extracting to the explicit target directory.
+        extracted = checker._unpacked(zip_path, target_dir)
+
+        # Then: extraction and returned paths use the explicit target only.
+        assert extracted == [target_dir / "data.txt"]
+        assert not configured_dir.exists()

--- a/tests/test_smarttable_checker_zip_encoding.py
+++ b/tests/test_smarttable_checker_zip_encoding.py
@@ -1,0 +1,303 @@
+"""Regression tests for issue #515: mojibake in SmartTable zip extraction.
+
+``SmartTableChecker._unpacked_smarttable()`` (src/rdetoolkit/impl/input_controller.py)
+delegates to ``shutil.unpack_archive()``, which in turn uses ``zipfile`` without any
+encoding awareness. ``zipfile`` decodes a filename as cp437 whenever the UTF-8
+language-encoding flag (general purpose bit 11, ``0x800``) is absent on the entry.
+Zips produced by legacy Windows tools in a Japanese locale store filenames as cp932
+(Shift_JIS) *without* setting that flag, so ``zipfile``'s cp437 decoding turns them
+into mojibake (e.g. ``'2θ_θ.TXT'.encode('cp932').decode('cp437')`` ->
+``'2â╞_â╞.TXT'``).
+
+These tests fix the *observable* behavior (extracted filenames must match the
+original text) as a regression harness, independent of whichever fix strategy
+Task 03 selects (hardcoded cp932, ``charset_normalizer`` detection, or
+``metadata_encoding``).
+
+Fixture construction:
+    ``zipfile.ZipInfo``/``zipfile.ZipFile.write()`` cannot be used to build the
+    cp932-without-flag fixture: CPython's ``ZipInfo._encodeFilenameFlags()``
+    unconditionally forces UTF-8 encoding + the ``0x800`` flag for any filename
+    that is not pure ASCII, even if ``flag_bits`` is cleared beforehand (verified
+    manually; see task log). Therefore this module builds STORED-method ZIP
+    archives directly at the byte level via ``_build_raw_zip``/``_write_raw_zip``,
+    which gives full control over the general-purpose flag bits and the raw
+    filename bytes per entry. No binary fixtures are committed to the repository.
+
+Equivalence Partitioning:
+| API | Input/State Partition | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| ``_unpacked_smarttable`` | cp932-encoded filename, UTF-8 flag unset | legacy Windows zip (bug repro) | extracted filename matches original Japanese text | TC-EP-ZIPENC-001 |
+| ``_unpacked_smarttable`` | UTF-8-encoded filename, UTF-8 flag set | modern zip tools / Python zipfile default | extracted filename unchanged (no regression) | TC-EP-ZIPENC-002 |
+| ``_unpacked_smarttable`` | ASCII-only filename | common case | extracted filename unchanged | TC-EP-ZIPENC-003 |
+| ``_unpacked_smarttable`` | zip mixing a UTF-8-flagged entry and a cp932-unflagged entry | real-world archives may mix tools | both filenames correctly resolved | TC-EP-ZIPENC-004 |
+
+Validation commands:
+Direct: ``uv run pytest tests/test_smarttable_checker_zip_encoding.py -v``
+Tox: ``tox -e py312-module -- tests/test_smarttable_checker_zip_encoding.py``
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+from rdetoolkit.impl.input_controller import MultiFileChecker, RDEFormatChecker, SmartTableChecker
+
+
+def _build_raw_zip(entries: list[tuple[bytes, bytes, bool]]) -> bytes:
+    """Build a minimal STORED-method ZIP archive with full per-entry control.
+
+    Controls the general-purpose flag bits and raw filename bytes per entry.
+    This bypasses ``zipfile.ZipInfo._encodeFilenameFlags()``, which always
+    forces UTF-8 + the language-encoding flag (bit 11 / ``0x800``) for any
+    filename that cannot be encoded as ASCII. That behavior makes it
+    impossible to reproduce a "cp932 bytes without the UTF-8 flag" ZIP (as
+    produced by legacy Windows zip tools) via the public ``zipfile`` API.
+
+    Only the STORED (uncompressed) method is supported, which is sufficient
+    for test fixtures; ``zipfile`` reads STORED entries without issue.
+
+    Args:
+        entries: List of ``(raw_filename_bytes, file_data_bytes,
+            use_utf8_flag)`` triples. ``use_utf8_flag`` controls whether the
+            UTF-8 language-encoding flag (bit 11) is set for that specific
+            entry, allowing a single archive to mix flagged and unflagged
+            entries.
+
+    Returns:
+        bytes: The complete ZIP archive contents.
+    """
+    buf = io.BytesIO()
+    offsets: list[int] = []
+    flags: list[int] = []
+
+    for filename_bytes, data, use_utf8_flag in entries:
+        flag = 0x0800 if use_utf8_flag else 0x0000
+        flags.append(flag)
+        offsets.append(buf.tell())
+        crc = zlib.crc32(data) & 0xFFFFFFFF
+        size = len(data)
+        buf.write(struct.pack(
+            "<IHHHHHIIIHH",
+            0x04034B50, 20, flag, 0, 0, 0,
+            crc, size, size, len(filename_bytes), 0,
+        ))
+        buf.write(filename_bytes)
+        buf.write(data)
+
+    central_start = buf.tell()
+    for (filename_bytes, data, _use_utf8_flag), offset, flag in zip(entries, offsets, flags, strict=True):
+        crc = zlib.crc32(data) & 0xFFFFFFFF
+        size = len(data)
+        buf.write(struct.pack(
+            "<IHHHHHHIIIHHHHHII",
+            0x02014B50, 20, 20, flag, 0, 0, 0,
+            crc, size, size, len(filename_bytes), 0, 0, 0, 0, 0,
+            offset,
+        ))
+        buf.write(filename_bytes)
+    central_size = buf.tell() - central_start
+
+    buf.write(struct.pack(
+        "<IHHHHIIH",
+        0x06054B50, 0, 0, len(entries), len(entries),
+        central_size, central_start, 0,
+    ))
+    return buf.getvalue()
+
+
+def _write_raw_zip(path: Path, entries: list[tuple[str, bytes, str, bool]]) -> None:
+    """Write a raw ZIP file where each filename is encoded per-entry.
+
+    Args:
+        path: Destination ``.zip`` path.
+        entries: List of ``(filename, file_content_bytes, encoding,
+            use_utf8_flag)`` tuples. ``encoding`` is the codec used to turn
+            ``filename`` into the raw bytes stored in the ZIP (e.g.
+            ``"cp932"``, ``"utf-8"``, ``"ascii"``); ``use_utf8_flag``
+            controls whether that entry's general-purpose flag advertises
+            UTF-8.
+    """
+    raw_entries = [
+        (name.encode(encoding), data, use_utf8_flag)
+        for name, data, encoding, use_utf8_flag in entries
+    ]
+    path.write_bytes(_build_raw_zip(raw_entries))
+
+
+def test_build_raw_zip_fixture_has_no_utf8_flag_and_raw_cp932_bytes(tmp_path: Path) -> None:
+    """Given/When/Then: guard the fixture helper itself.
+
+    Given a cp932-encoded filename written via ``_write_raw_zip`` with
+    ``use_utf8_flag=False``.
+    When the resulting archive is inspected with ``zipfile.ZipInfo``.
+    Then the stored general-purpose flag must NOT have bit 11 (``0x800``)
+    set, and re-encoding the (cp437-mis-decoded) stored name as cp437 must
+    round-trip back to the original cp932 bytes. This proves the fixture
+    genuinely reproduces a flag-less legacy-Windows zip rather than silently
+    being UTF-8-flagged (which would make the reproduction test pass
+    vacuously).
+    """
+    name = "NB1_800_20220214_2θ_θ.TXT"
+    zip_path = tmp_path / "guard.zip"
+
+    _write_raw_zip(zip_path, [(name, b"dummy", "cp932", False)])
+
+    with zipfile.ZipFile(zip_path) as zf:
+        info = zf.infolist()[0]
+        # The UTF-8 language-encoding flag (bit 11) must be unset.
+        assert info.flag_bits & 0x800 == 0
+        # zipfile decoded the raw bytes as cp437 (its default for unflagged
+        # entries); re-encoding as cp437 must recover the original cp932 bytes.
+        assert info.filename.encode("cp437") == name.encode("cp932")
+
+
+class TestSmartTableCheckerZipEncoding:
+    """Regression tests for issue #515: mojibake in SmartTable zip extraction."""
+
+    def test_cp932_filename_without_utf8_flag_is_decoded_correctly(self, tmp_path: Path) -> None:
+        """TC-EP-ZIPENC-001: cp932 filename without the UTF-8 flag (bug repro)."""
+        # Given: a zip whose filename is cp932-encoded without the UTF-8 flag,
+        # reproducing an exact filename reported in issue #515.
+        zip_path = tmp_path / "inputdata_hoge.zip"
+        _write_raw_zip(
+            zip_path,
+            [("NB1_800_20220214_2θ_θ.TXT", b"dummy", "cp932", False)],
+        )
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = SmartTableChecker(out_dir)
+
+        # When: extracting via the same code path SmartTable mode uses.
+        extracted = checker._unpacked_smarttable(zip_path)
+
+        # Then: the extracted filename must match the original text, not mojibake.
+        names = [f.name for f in extracted]
+        assert "NB1_800_20220214_2θ_θ.TXT" in names
+        assert "NB1_800_20220214_2â╞_â╞.TXT" not in names  # the observed mojibake
+
+    def test_utf8_flagged_filename_still_works(self, tmp_path: Path) -> None:
+        """TC-EP-ZIPENC-002: UTF-8-flagged filename must not regress."""
+        # Given: a zip written the "normal" way (Python zipfile auto-sets
+        # the UTF-8 flag for non-ASCII names) — must not regress.
+        zip_path = tmp_path / "utf8.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("日本語ファイル.txt", "dummy")
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = SmartTableChecker(out_dir)
+
+        # When: extracting via the same code path SmartTable mode uses.
+        extracted = checker._unpacked_smarttable(zip_path)
+
+        # Then: the extracted filename is unchanged.
+        assert "日本語ファイル.txt" in [f.name for f in extracted]
+
+    def test_ascii_filename_unaffected(self, tmp_path: Path) -> None:
+        """TC-EP-ZIPENC-003: pure-ASCII filenames are unaffected either way."""
+        # Given: an ASCII-only filename, unflagged (as real unflagged zips are).
+        zip_path = tmp_path / "ascii.zip"
+        _write_raw_zip(zip_path, [("data.txt", b"dummy", "ascii", False)])
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = SmartTableChecker(out_dir)
+
+        # When: extracting via the same code path SmartTable mode uses.
+        extracted = checker._unpacked_smarttable(zip_path)
+
+        # Then: the extracted filename is unchanged.
+        assert "data.txt" in [f.name for f in extracted]
+
+    def test_mixed_flagged_and_unflagged_entries_in_same_zip(self, tmp_path: Path) -> None:
+        """TC-EP-ZIPENC-004: a single archive mixing both encodings.
+
+        Real-world archives can be assembled from files added by different
+        tools/eras, so one entry may carry the UTF-8 flag while another
+        (e.g. added by a legacy Windows zip tool) does not. Both filenames
+        must resolve correctly from the same extraction call, using the
+        second reported issue #515 filename for the unflagged entry.
+        """
+        # Given: one entry written the "normal" (UTF-8 flagged) way and one
+        # entry that is cp932-encoded without the flag, combined into a
+        # single archive.
+        zip_path = tmp_path / "mixed.zip"
+        _write_raw_zip(
+            zip_path,
+            [
+                ("日本語ファイル.txt", b"dummy", "utf-8", True),
+                ("20211014T5高圧_2θ_θ.TXT", b"dummy", "cp932", False),
+            ],
+        )
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = SmartTableChecker(out_dir)
+
+        # When: extracting via the same code path SmartTable mode uses.
+        extracted = checker._unpacked_smarttable(zip_path)
+
+        # Then: both filenames are correctly resolved.
+        names = [f.name for f in extracted]
+        assert "日本語ファイル.txt" in names
+        assert "20211014T5高圧_2θ_θ.TXT" in names
+
+
+@pytest.mark.parametrize("checker_cls", [RDEFormatChecker, MultiFileChecker])
+class TestOtherCheckersZipEncoding:
+    """Issue #515 sibling defects: the same mojibake in RDEFormat/MultiFile modes.
+
+    ``RDEFormatChecker._unpacked`` and ``MultiFileChecker._unpacked`` used the
+    identical ``shutil.unpack_archive()`` pattern as the SmartTable defect that
+    issue #515 reported, so the same legacy Windows zip garbles filenames in
+    those modes too. These were fixed alongside the reported mode; these tests
+    pin that down.
+    """
+
+    def test_cp932_filename_without_utf8_flag_is_decoded_correctly(
+        self,
+        checker_cls: type[RDEFormatChecker | MultiFileChecker],
+        tmp_path: Path,
+    ) -> None:
+        """TC-EP-ZIPENC-005: cp932 filename without the UTF-8 flag."""
+        # Given: a zip whose filename is cp932-encoded without the UTF-8 flag.
+        zip_path = tmp_path / "inputdata_hoge.zip"
+        _write_raw_zip(
+            zip_path,
+            [("NB1_800_20220214_2θ_θ.TXT", b"dummy", "cp932", False)],
+        )
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = checker_cls(out_dir)
+
+        # When: extracting via the code path this mode uses.
+        extracted = checker._unpacked(zip_path, out_dir)
+
+        # Then: the extracted filename must match the original text, not mojibake.
+        names = [f.name for f in extracted]
+        assert "NB1_800_20220214_2θ_θ.TXT" in names
+        assert "NB1_800_20220214_2â╞_â╞.TXT" not in names
+
+    def test_utf8_flagged_filename_still_works(
+        self,
+        checker_cls: type[RDEFormatChecker | MultiFileChecker],
+        tmp_path: Path,
+    ) -> None:
+        """TC-EP-ZIPENC-006: UTF-8-flagged filenames keep working."""
+        # Given: a zip written the modern way (UTF-8 flag set).
+        zip_path = tmp_path / "modern.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("日本語ファイル.txt", b"dummy")
+        out_dir = tmp_path / "temp"
+        out_dir.mkdir()
+        checker = checker_cls(out_dir)
+
+        # When: extracting via the code path this mode uses.
+        extracted = checker._unpacked(zip_path, out_dir)
+
+        # Then: the filename is unchanged.
+        assert [f.name for f in extracted] == ["日本語ファイル.txt"]

--- a/tests/test_zip_encoding.py
+++ b/tests/test_zip_encoding.py
@@ -1,0 +1,184 @@
+"""Unit tests for the shared zip filename encoding helper (issue #515).
+
+``rdetoolkit.impl._zip_encoding.resolve_filename`` decides what filename a zip
+entry should be extracted under. ``zipfile`` has already decoded the name by the
+time it is called -- as UTF-8 when the language encoding flag (general purpose
+bit 11, ``0x800``) is set, otherwise as cp437 -- so this function's job is to
+decide whether that decoding can be trusted and repair it when it cannot.
+
+These tests target ``resolve_filename`` directly, rather than through an
+extraction call, so that the fallback branches can be exercised in isolation.
+End-to-end coverage through the checkers lives in
+``tests/test_smarttable_checker_zip_encoding.py``.
+
+Equivalence Partitioning:
+| Input/State Partition | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- |
+| UTF-8 flag set | spec guarantees UTF-8; zipfile already correct | name returned verbatim, no detection | TC-EP-RESOLVE-001 |
+| cp932 bytes, flag unset | legacy Japanese Windows zip (the issue #515 bug) | name recovered as cp932 | TC-EP-RESOLVE-002 |
+| ASCII bytes, flag unset | common case | name unchanged | TC-EP-RESOLVE-003 |
+| bytes cp932 cannot decode, flag unset | non-Japanese legacy zip | falls back to detection, never raises | TC-EP-RESOLVE-004 |
+| detection returns an unusable codec | heuristic failure | warns and keeps zipfile's name; never raises | TC-EP-RESOLVE-005 |
+| detection returns None | heuristic yields nothing | falls back to cp437 (zipfile's own default) | TC-EP-RESOLVE-006 |
+
+Validation commands:
+Direct: ``uv run pytest tests/test_zip_encoding.py -v``
+Tox: ``tox -e py312-module -- tests/test_zip_encoding.py``
+"""
+
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+from rdetoolkit.impl import _zip_encoding
+from rdetoolkit.impl._zip_encoding import LANG_ENC_FLAG, resolve_filename
+
+
+def _zip_info_for(raw_name: bytes, *, utf8_flag: bool) -> zipfile.ZipInfo:
+    """Build a ZipInfo as ``zipfile`` would present it after parsing an archive.
+
+    Args:
+        raw_name: The filename bytes as stored in the archive.
+        utf8_flag: Whether the entry advertises UTF-8 (general purpose bit 11).
+
+    Returns:
+        zipfile.ZipInfo: Entry whose ``filename`` is decoded the way ``zipfile``
+            itself would decode it, and whose ``flag_bits`` match ``utf8_flag``.
+    """
+    info = zipfile.ZipInfo()
+    info.filename = raw_name.decode("utf-8" if utf8_flag else "cp437")
+    info.flag_bits = LANG_ENC_FLAG if utf8_flag else 0
+    return info
+
+
+class TestResolveFilename:
+    """Issue #515: recovering true filenames from non-UTF-8 zip entries."""
+
+    def test_utf8_flagged_name_is_returned_verbatim(self) -> None:
+        """TC-EP-RESOLVE-001: a flagged name is trusted without detection."""
+        # Given: an entry that advertises UTF-8, as modern zip tools produce.
+        name = "日本語ファイル.txt"
+        info = _zip_info_for(name.encode("utf-8"), utf8_flag=True)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: zipfile's decoding is trusted as-is.
+        assert result == name
+
+    def test_utf8_flagged_name_skips_detection_entirely(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TC-EP-RESOLVE-001: detection must not run for flagged entries.
+
+        Detection is heuristic and mis-reads short names, so a name the spec
+        already guarantees to be correct must never be passed through it.
+        """
+        # Given: detection that fails loudly if it is ever consulted.
+        def _boom(_: bytes) -> dict[str, str]:
+            pytest.fail("charset_normalizer.detect() must not run for UTF-8-flagged entries")
+
+        monkeypatch.setattr(_zip_encoding.charset_normalizer, "detect", _boom)
+        info = _zip_info_for("データ.txt".encode(), utf8_flag=True)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: the name survives and detection was never called.
+        assert result == "データ.txt"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "NB1_800_20220214_2θ_θ.TXT",
+            "20211014T5高圧_2θ_θ.TXT",
+            "日本語ファイル.txt",
+            "データ.txt",
+            "測定結果_2023.csv",
+        ],
+    )
+    def test_cp932_name_without_flag_is_recovered(self, name: str) -> None:
+        """TC-EP-RESOLVE-002: cp932 names are recovered (the issue #515 bug).
+
+        ``charset_normalizer`` alone reads several of these as cp949 or
+        utf_16_le and corrupts them, which is why cp932 is tried first.
+        """
+        # Given: an unflagged entry whose stored bytes are cp932.
+        info = _zip_info_for(name.encode("cp932"), utf8_flag=False)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: the original Japanese text is recovered.
+        assert result == name
+
+    def test_ascii_name_without_flag_is_unchanged(self) -> None:
+        """TC-EP-RESOLVE-003: ASCII names pass through untouched."""
+        # Given: an unflagged entry with a pure-ASCII name.
+        info = _zip_info_for(b"data.txt", utf8_flag=False)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: the name is unchanged.
+        assert result == "data.txt"
+
+    def test_undecodable_cp932_falls_back_to_detection(self) -> None:
+        """TC-EP-RESOLVE-004: non-cp932 legacy names reach the fallback.
+
+        ``0x81 0x20`` is an illegal cp932 multibyte sequence, so cp932 decoding
+        raises and detection takes over. The result may be imperfect, but the
+        call must return a name rather than propagate the error.
+        """
+        # Given: an unflagged entry whose bytes cp932 cannot decode.
+        raw = bytes([0x81, 0x20]) + b"_bad.TXT"
+        with pytest.raises(UnicodeDecodeError):
+            raw.decode("cp932")  # guard: the fixture really does defeat cp932
+        info = _zip_info_for(raw, utf8_flag=False)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: some name comes back and nothing is raised.
+        assert isinstance(result, str)
+        assert result
+
+    def test_unusable_detected_codec_keeps_zipfile_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TC-EP-RESOLVE-005: a bogus detection result must not abort the zip.
+
+        Detection is heuristic and can name a codec that does not exist or
+        cannot decode these bytes. One unreadable filename must not take the
+        whole archive down with it.
+        """
+        # Given: detection that names a codec Python does not have.
+        monkeypatch.setattr(
+            _zip_encoding.charset_normalizer,
+            "detect",
+            lambda _: {"encoding": "not-a-real-codec"},
+        )
+        raw = bytes([0x81, 0x20]) + b"_bad.TXT"
+        info = _zip_info_for(raw, utf8_flag=False)
+        fallback_name = info.filename
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: zipfile's own name is kept instead of raising.
+        assert result == fallback_name
+
+    def test_detection_returning_none_falls_back_to_cp437(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TC-EP-RESOLVE-006: no detection result means cp437, zipfile's default."""
+        # Given: detection that yields no encoding at all.
+        monkeypatch.setattr(
+            _zip_encoding.charset_normalizer,
+            "detect",
+            lambda _: {"encoding": None},
+        )
+        raw = bytes([0x81, 0x20]) + b"_bad.TXT"
+        info = _zip_info_for(raw, utf8_flag=False)
+
+        # When: resolving the filename.
+        result = resolve_filename(info)
+
+        # Then: the cp437 reading (what zipfile produced) is used.
+        assert result == raw.decode("cp437")

--- a/tests/test_zip_encoding.py
+++ b/tests/test_zip_encoding.py
@@ -12,14 +12,23 @@ End-to-end coverage through the checkers lives in
 ``tests/test_smarttable_checker_zip_encoding.py``.
 
 Equivalence Partitioning:
-| Input/State Partition | Rationale | Expected Outcome | Test ID |
-| --- | --- | --- | --- |
-| UTF-8 flag set | spec guarantees UTF-8; zipfile already correct | name returned verbatim, no detection | TC-EP-RESOLVE-001 |
-| cp932 bytes, flag unset | legacy Japanese Windows zip (the issue #515 bug) | name recovered as cp932 | TC-EP-RESOLVE-002 |
-| ASCII bytes, flag unset | common case | name unchanged | TC-EP-RESOLVE-003 |
-| bytes cp932 cannot decode, flag unset | non-Japanese legacy zip | falls back to detection, never raises | TC-EP-RESOLVE-004 |
-| detection returns an unusable codec | heuristic failure | warns and keeps zipfile's name; never raises | TC-EP-RESOLVE-005 |
-| detection returns None | heuristic yields nothing | falls back to cp437 (zipfile's own default) | TC-EP-RESOLVE-006 |
+| API | Input/State Partition | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| ``resolve_filename`` | UTF-8 flag set | spec guarantees UTF-8; zipfile already correct | name returned verbatim, no detection | TC-EP-RESOLVE-001 |
+| ``resolve_filename`` | cp932 bytes, flag unset | legacy Japanese Windows zip (the issue #515 bug) | name recovered as cp932 | TC-EP-RESOLVE-002 |
+| ``resolve_filename`` | ASCII bytes, flag unset | common case | name unchanged | TC-EP-RESOLVE-003 |
+| ``resolve_filename`` | bytes cp932 cannot decode, flag unset | non-Japanese legacy zip | falls back to detection, never raises | TC-EP-RESOLVE-004 |
+| ``resolve_filename`` | detection returns an unusable codec | heuristic failure | warns and keeps zipfile's name; never raises | TC-EP-RESOLVE-005 |
+| ``resolve_filename`` | detection returns None | heuristic yields nothing | falls back to cp437 (zipfile's own default) | TC-EP-RESOLVE-006 |
+| ``extract_zip_with_encoding`` | safe nested entry | normal archive hierarchy | extracts beneath destination | TC-EP-EXTRACT-001 |
+| ``extract_zip_with_encoding`` | parent traversal entry | Zip Slip attempt | warns and skips entry | TC-EP-EXTRACT-002 |
+| ``extract_zip_with_encoding`` | absolute path entry | Zip Slip attempt | warns and skips entry | TC-EP-EXTRACT-003 |
+
+Boundary Value:
+| API | Boundary | Rationale | Expected Outcome | Test ID |
+| --- | --- | --- | --- | --- |
+| ``extract_zip_with_encoding`` | destination child at depth 1 | nearest path inside extraction root | extracts entry | TC-BV-EXTRACT-001 |
+| ``extract_zip_with_encoding`` | destination parent via one ``..`` | nearest path outside extraction root | skips entry | TC-BV-EXTRACT-002 |
 
 Validation commands:
 Direct: ``uv run pytest tests/test_zip_encoding.py -v``
@@ -29,11 +38,16 @@ Tox: ``tox -e py312-module -- tests/test_zip_encoding.py``
 from __future__ import annotations
 
 import zipfile
+from pathlib import Path
 
 import pytest
 
 from rdetoolkit.impl import _zip_encoding
-from rdetoolkit.impl._zip_encoding import LANG_ENC_FLAG, resolve_filename
+from rdetoolkit.impl._zip_encoding import (
+    LANG_ENC_FLAG,
+    extract_zip_with_encoding,
+    resolve_filename,
+)
 
 
 def _zip_info_for(raw_name: bytes, *, utf8_flag: bool) -> zipfile.ZipInfo:
@@ -182,3 +196,65 @@ class TestResolveFilename:
 
         # Then: the cp437 reading (what zipfile produced) is used.
         assert result == raw.decode("cp437")
+
+
+class TestExtractZipWithEncoding:
+    """Secure extraction tests for the shared ZIP helper."""
+
+    def test_safe_nested_entry_is_extracted__tc_ep_extract_001__tc_bv_extract_001(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Extract a nearest-child entry beneath the destination."""
+        # Given: a normal archive containing one nested file.
+        zip_path = tmp_path / "safe.zip"
+        with zipfile.ZipFile(zip_path, "w") as zip_ref:
+            zip_ref.writestr("nested/data.txt", b"safe")
+        extract_path = tmp_path / "extract"
+
+        # When: extracting the archive.
+        extract_zip_with_encoding(zip_path, extract_path)
+
+        # Then: the file is written beneath the extraction root.
+        assert (extract_path / "nested" / "data.txt").read_bytes() == b"safe"
+
+    def test_parent_traversal_is_skipped__tc_ep_extract_002__tc_bv_extract_002(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Skip an entry resolving one level above the destination."""
+        # Given: an archive entry targeting the extraction directory's parent.
+        zip_path = tmp_path / "traversal.zip"
+        with zipfile.ZipFile(zip_path, "w") as zip_ref:
+            zip_ref.writestr("../escaped.txt", b"unsafe")
+        extract_path = tmp_path / "extract"
+
+        # When: extracting the archive.
+        extract_zip_with_encoding(zip_path, extract_path)
+
+        # Then: the unsafe entry is not written and the skip is visible.
+        assert not (tmp_path / "escaped.txt").exists()
+        assert not (extract_path / "escaped.txt").exists()
+        assert "Skipping unsafe zip entry '../escaped.txt'" in caplog.text
+
+    def test_absolute_path_is_skipped__tc_ep_extract_003(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Skip an entry whose name is an absolute path."""
+        # Given: an archive entry with an absolute destination.
+        zip_path = tmp_path / "absolute.zip"
+        outside_path = tmp_path / "absolute-escaped.txt"
+        with zipfile.ZipFile(zip_path, "w") as zip_ref:
+            zip_ref.writestr(str(outside_path), b"unsafe")
+        extract_path = tmp_path / "extract"
+
+        # When: extracting the archive.
+        extract_zip_with_encoding(zip_path, extract_path)
+
+        # Then: the absolute path is not written and the skip is visible.
+        assert not outside_path.exists()
+        assert not extract_path.exists()
+        assert f"Skipping unsafe zip entry {str(outside_path)!r}" in caplog.text


### PR DESCRIPTION
### **User description**
## Related Issue

Fixes #515

## Changes

SmartTable mode failed with `SmartTable row 3 references missing file in uploaded zip: inputdata1=NB1_800_20220214_2θ_θ.TXT` because filenames inside the uploaded zip were garbled on extraction.

`SmartTableChecker._unpacked_smarttable()` called `shutil.unpack_archive()`, which delegates to `zipfile`. Per the ZIP specification, the filename encoding is only defined when general purpose bit 11 (`0x800`) is set, in which case it is UTF-8; without that flag `zipfile` decodes filenames as cp437. Archives created on Japanese Windows store cp932 filenames without the flag, so `'2θ_θ.TXT'.encode('cp932').decode('cp437')` yields `'2â╞_â╞.TXT'`.

**New shared helper** — `src/rdetoolkit/impl/_zip_encoding.py`:

- UTF-8 flag set: trust the name `zipfile` produced. The spec guarantees UTF-8, so running encoding detection over it can only corrupt a name that is already correct.
- Flag absent: re-encode as cp437 to recover the raw bytes (cp437 maps all 256 byte values, so this always round-trips), then decode as cp932.
- Only if cp932 raises `UnicodeDecodeError`, fall back to `charset_normalizer` detection.
- If that also fails, log a warning and keep `zipfile`'s name. A single unreadable filename must not abort extraction of the whole archive.

**cp932 is tried before statistical detection because the detection is measurably wrong on filenames.** `charset_normalizer.detect()` needs more data than a filename carries: it reads `NB1_800_20220214_2θ_θ.TXT` as CP949 and `データ.txt` as utf_16_le, corrupting both. Reusing the existing detection-based logic as-is would not have fixed this issue.

**All extraction paths now route through the shared helper**, removing `shutil.unpack_archive()` from `src/` entirely:

| Location | Change |
|---|---|
| `impl/input_controller.py` | `SmartTableChecker._unpacked_smarttable` (the reported defect), plus `RDEFormatChecker._unpacked` and `MultiFileChecker._unpacked`, which carried the identical defect. Renamed the `zipfile` parameter to `zip_path` — it shadowed the stdlib module. Dropped the now-unused `import shutil`. |
| `impl/compressed_controller.py` | `CompressedFlatFileParser._extract_zip_with_encoding` and `CompressedFolderParser._extract_zip_with_encoding` were byte-identical duplicates; both now delegate to the helper. This also fixes the same mis-detection in ExcelInvoice mode, which had no test coverage and was silently broken for Japanese filenames. |

The issue text states that ExcelInvoice mode already handled encoding correctly. That was not the case — it used the same unreliable detection and garbled the same filenames.

**Tests** — `tests/test_smarttable_checker_zip_encoding.py` (9) and `tests/test_zip_encoding.py` (11):

Fixtures are built programmatically; no binary fixtures are committed. The public `zipfile` API cannot produce the archive this bug needs — CPython's `ZipInfo._encodeFilenameFlags()` unconditionally re-sets the UTF-8 flag for any non-ASCII name, even when `flag_bits` is cleared first — so the tests assemble STORED-format archives at the byte level, controlling the flag per entry. A dedicated test guards the fixture itself: without it, a fixture that silently set the UTF-8 flag would make the reproduction test pass vacuously and hide the bug.

Coverage of `_zip_encoding.py` is 100% (35 statements). The detection-fallback and warn-and-continue branches are covered using an invalid cp932 byte sequence (`0x81 0x20`) and monkeypatched detection results.

## Out of Scope

- **Non-Japanese legacy archives.** Preferring cp932 silently mis-decodes any non-UTF-8 archive whose raw bytes form valid cp932 sequences — this is broader than Korean cp949. Of 53 cp437-representable Latin-1 characters, 18 (`á í ñ ó ú Ç Ñ ¿` and similar, common in Western European filenames) decode without raising and therefore never reach the fallback. Accepted deliberately: RDE's users are on Japanese Windows, and a reported production failure outweighs a hypothetical one. `PREFERRED_ENCODING` is factored out as a constant should this need to become configurable via `config.toml` later.
- **`rde2util.unzip_japanese_zip()`** is left untouched. It has no internal callers, but it is a public API documented in `docs/rdetoolkit/rde2util.md` with a stub in `rde2util.pyi`, so external code may import it.
- **`zipfile.ZipFile(..., metadata_encoding='cp932')`** was considered and rejected. It requires Python 3.11+, while `requires-python` is `>= 3.10`; the 3.10 fallback branch would reimplement this helper anyway, and CI only runs py312, so that branch would ship untested.
- **Pre-existing failures**, verified unchanged by stashing this branch's changes: 61 failures in `tests/test_graph_outputs.py` (matplotlib baseline-image comparisons, environment-dependent) and 2 mypy errors in `models/rde2types.py:1036` (duplicate definition).
- **`tests/test_smarttable_checker.py:35`** hardcodes `Path("data/temp")`, so running the suite creates an untracked `data/` directory that is not in `.gitignore`.

## Verification

- [x] CI tests pass successfully
- [x] No issues with the modified scripts

| Check | Result |
|---|---|
| `pytest tests/test_smarttable_checker_zip_encoding.py` | 9 passed |
| `pytest tests/test_zip_encoding.py` | 11 passed |
| `pytest tests/ --ignore=tests/test_graph_outputs.py` | 2027 passed, 4 skipped |
| `ruff check src/rdetoolkit/ tests/` | clean |
| `mypy src/` | 2 errors, both pre-existing in `models/rde2types.py` |
| Coverage of `_zip_encoding.py` | 100% (35 stmts, 0 miss) |

Reproduction check: both filenames from the issue report (`NB1_800_20220214_2θ_θ.TXT`, `20211014T5高圧_2θ_θ.TXT`) now extract under their original names. Both tests were confirmed RED against the unfixed code before the fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests, Enhancement, Documentation


___

### **Description**
- Fix cp932 ZIP filename decoding for Japanese Windows archives
  - Recover original filenames when UTF-8 flag is absent
  - Apply fix to SmartTable, RDEFormat, MultiFile, ExcelInvoice extraction
  - Add path traversal protection for ZIP extraction

- Add comprehensive regression and unit tests for ZIP filename handling
  - Test cp932, UTF-8, ASCII, and mixed encoding scenarios
  - Validate extraction security (Zip Slip prevention)

- Refactor extraction logic to use a shared helper module
  - Remove duplicated encoding logic and `shutil.unpack_archive` usage

- Update release notes (EN/JA) to document the bugfix and new behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZIP extraction in input_controller & compressed_controller"] -- "was: shutil.unpack_archive (no encoding fix)" --> B["Now: extract_zip_with_encoding (shared helper)"]
  B -- "calls" --> C["resolve_filename (recovers cp932/UTF-8/ASCII)"]
  B -- "validates path stays within extraction root" --> D["Path traversal protection"]
  A2["SmartTable, RDEFormat, MultiFile, ExcelInvoice"] -- "all use" --> B
  E["Regression & unit tests"] -- "cover all scenarios" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>_zip_encoding.py</strong><dd><code>Add shared ZIP extraction helper for filename encoding</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-0fe406555e10709459bdcb9daf052132c0fa94f858dcfb9d3a2eb4bd0c8fe296">+114/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>_zip_encoding.pyi</strong><dd><code>Add type stub for ZIP encoding helper module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-af3cc6c2528008de39cdcfe4749b4e2afbb5f053873785ff09c8674002c94f41">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_controller.py</strong><dd><code>Refactor to use shared ZIP extraction helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-1ba2eed082860db640f1dd55641b7af16fd4566f7f1823cbfb993190871da84c">+14/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>compressed_controller.py</strong><dd><code>Refactor to use shared ZIP extraction helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-8ee19c61af149e1316e45043e5361b434d39c57cf3f00d1d86b56edef78496e0">+3/-40</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_smarttable_checker_zip_encoding.py</strong><dd><code>Add regression tests for ZIP filename encoding (SmartTable, RDEFormat, </code><br><code>MultiFile)</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-9acaa93952abfea753b893942577e9958a2191b64515bf13582cca6a24c99cc4">+325/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_zip_encoding.py</strong><dd><code>Add unit tests for ZIP filename resolution and extraction security</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-640d854cd082542750950c6133345eb987cb3c118e63e8281869a6d091d3493b">+260/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>index.en.md</strong><dd><code>Update release notes for v1.7.1 with ZIP filename bugfix</code>&nbsp; </dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-4927398bbc5416d2373f7d5ab4f4dbc448bd1d02438f0017b365b025d50e3095">+39/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ja.md</strong><dd><code>Update Japanese release notes for v1.7.1 with ZIP filename bugfix</code></dd></td>
  <td><a href="https://github.com/nims-mdpf/rdetoolkit/pull/518/files#diff-918a15bad39655ff5c737a14fdb798f5f9befb7357cdf4d61bab286a791e64bc">+38/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

